### PR TITLE
Added support for wildcard in group requirements.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -166,7 +166,7 @@ func parseCLIOptions(cx *cli.Context, config *Config) (err error) {
 	for i := 0; i < count; i++ {
 		field := reflect.TypeOf(config).Elem().Field(i)
 		name := field.Tag.Get("yaml")
-		if containedIn(name, ignoredOptions) {
+		if containedIn(name, ignoredOptions, false) {
 			continue
 		}
 

--- a/handlers.go
+++ b/handlers.go
@@ -81,7 +81,7 @@ func (r *oauthProxy) oauthAuthorizationHandler(w http.ResponseWriter, req *http.
 
 	// step: set the access type of the session
 	var accessType string
-	if containedIn("offline", r.config.Scopes) {
+	if containedIn("offline", r.config.Scopes, false) {
 		accessType = "offline"
 	}
 
@@ -214,7 +214,7 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 			if err != nil {
 				r.log.Warn("app did send a corrupted redirectURI in cookie: invalid url espcaping", zap.Error(err))
 			}
-			// Since the value is passed wih a cookie, we do not expect the client to use base64url (but the
+			// Since the value is passed with a cookie, we do not expect the client to use base64url (but the
 			// base64-encoded value may itself be url-encoded).
 			// This is safe for browsers using atob() but needs to be treated with care for nodeJS clients,
 			// which natively use base64url encoding, and url-escape padding '=' characters.

--- a/middleware.go
+++ b/middleware.go
@@ -265,7 +265,7 @@ func (r *oauthProxy) checkClaim(user *userContext, claimName string, match *rege
 				return true
 			}
 		}
-		r.log.Warn("claim requirement does not match any element claim group in token", append(errFields,
+		r.log.Warn("claim requirement does not match any claim in token", append(errFields,
 			zap.String("issued", fmt.Sprintf("%v", valueStrs)),
 			zap.String("required", match.String()),
 		)...)
@@ -304,7 +304,7 @@ func (r *oauthProxy) admissionMiddleware(resource *Resource) func(http.Handler) 
 			user := scope.Identity
 
 			// @step: we need to check the roles
-			if !hasAccess(resource.Roles, user.roles, !resource.RequireAnyRole) {
+			if !hasAccess(resource.Roles, user.roles, !resource.RequireAnyRole, false) {
 				r.log.Warn("access denied, invalid roles",
 					zap.String("access", "denied"),
 					zap.String("email", user.email),
@@ -316,7 +316,7 @@ func (r *oauthProxy) admissionMiddleware(resource *Resource) func(http.Handler) 
 			}
 
 			// @step: check if we have any groups, the groups are there
-			if !hasAccess(resource.Groups, user.groups, false) {
+			if !hasAccess(resource.Groups, user.groups, false, true) {
 				r.log.Warn("access denied, invalid groups",
 					zap.String("access", "denied"),
 					zap.String("email", user.email),

--- a/rotation.go
+++ b/rotation.go
@@ -79,7 +79,7 @@ func (c *certificationRotation) watch() error {
 			case event := <-watcher.Events:
 				if event.Op&fsnotify.Write == fsnotify.Write {
 					// step: does the change effect our files?
-					if !containedIn(event.Name, filewatchPaths) {
+					if !containedIn(event.Name, filewatchPaths, false) {
 						continue
 					}
 					// step: reload the certificate


### PR DESCRIPTION
E.g. expression for check may be written "group/subgroup/*".

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>