### PR TITLE
[KEYCLOAK-9870] Fix refresh token issue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
   golint:
     min-confidence: 0
   gocyclo:
-    min-complexity: 60
+    min-complexity: 90
   maligned:
     suggest-new: true
   dupl:

--- a/handlers.go
+++ b/handlers.go
@@ -499,7 +499,7 @@ func (r *oauthProxy) proxyMetricsHandler(w http.ResponseWriter, req *http.Reques
 }
 
 // retrieveRefreshToken retrieves the refresh token from store or cookie
-func (r *oauthProxy) retrieveRefreshToken(req *http.Request, user *userContext) (token, ecrypted string, err error) {
+func (r *oauthProxy) retrieveRefreshToken(req *http.Request, user *userContext) (token, encrypted string, err error) {
 	switch r.useStore() {
 	case true:
 		token, err = r.GetRefreshToken(user.token)
@@ -510,7 +510,7 @@ func (r *oauthProxy) retrieveRefreshToken(req *http.Request, user *userContext) 
 		return
 	}
 
-	ecrypted = token // returns encryped, avoid encoding twice
+	encrypted = token // returns encrypted, avoids encoding twice
 	token, err = decodeText(token, r.config.EncryptionKey)
 	return
 }

--- a/middleware.go
+++ b/middleware.go
@@ -168,8 +168,15 @@ func (r *oauthProxy) authenticationMiddleware() func(http.Handler) http.Handler 
 						return
 					}
 
-					// attempt to refresh the access token
-					token, exp, err := getRefreshedToken(r.client, refresh)
+					// attempt to refresh the access token, possibly with a renewed refresh token
+					//
+					// NOTE: atm, this does not retrieve explicit refresh token expiry from oauth2,
+					// and take identity expiry instead: with keycloak, they are the same and equal to
+					// "SSO session idle" keycloak setting.
+					//
+					// exp: expiration of the access token
+					// expiresIn: expiration of the ID token
+					token, newRefreshToken, accessExpiresAt, refreshExpiresIn, err := getRefreshedToken(r.client, refresh)
 					if err != nil {
 						switch err {
 						case ErrRefreshTokenExpired:
@@ -185,14 +192,24 @@ func (r *oauthProxy) authenticationMiddleware() func(http.Handler) http.Handler 
 
 						return
 					}
-					// get the expiration of the new access token
-					expiresIn := r.getAccessCookieExpiration(token, refresh)
+
+					accessExpiresIn := time.Until(accessExpiresAt)
+
+					// get the expiration of the new refresh token
+					if newRefreshToken != "" {
+						refresh = newRefreshToken
+					}
+					if refreshExpiresIn == 0 {
+						// refresh token expiry claims not available: try to parse refresh token
+						refreshExpiresIn = r.getAccessCookieExpiration(token, refresh)
+					}
 
 					r.log.Info("injecting the refreshed access token cookie",
 						zap.String("client_ip", clientIP),
 						zap.String("cookie_name", r.config.CookieAccessName),
 						zap.String("email", user.email),
-						zap.Duration("expires_in", time.Until(exp)))
+						zap.Duration("refresh_expires_in", refreshExpiresIn),
+						zap.Duration("expires_in", accessExpiresIn))
 
 					accessToken := token.Encode()
 					if r.config.EnableEncryptedToken || r.config.ForceEncryptedCookie {
@@ -203,7 +220,20 @@ func (r *oauthProxy) authenticationMiddleware() func(http.Handler) http.Handler 
 						}
 					}
 					// step: inject the refreshed access token
-					r.dropAccessTokenCookie(req.WithContext(ctx), w, accessToken, expiresIn)
+					r.dropAccessTokenCookie(req.WithContext(ctx), w, accessToken, accessExpiresIn)
+
+					// step: inject the renewed refresh token
+					if newRefreshToken != "" {
+						r.log.Debug("renew refresh cookie with new refresh token",
+							zap.Duration("refresh_expires_in", refreshExpiresIn))
+						encryptedRefreshToken, err := encodeText(newRefreshToken, r.config.EncryptionKey)
+						if err != nil {
+							r.log.Error("failed to encrypt the refresh token", zap.Error(err))
+							w.WriteHeader(http.StatusInternalServerError)
+							return
+						}
+						r.dropRefreshTokenCookie(req.WithContext(ctx), w, encryptedRefreshToken, refreshExpiresIn)
+					}
 
 					if r.useStore() {
 						go func(old, new jose.JWT, encrypted string) {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -91,7 +91,6 @@ func newFakeProxy(c *Config) *fakeProxy {
 	auth := newFakeAuthServer()
 	c.DiscoveryURL = auth.getLocation()
 	c.RevocationEndpoint = auth.getRevocationURL()
-	c.Verbose = true
 	proxy, err := newProxy(c)
 	if err != nil {
 		panic("failed to create fake proxy service, error: " + err.Error())
@@ -1049,6 +1048,7 @@ func TestCheckRefreshTokens(t *testing.T) {
 	cfg := newFakeKeycloakConfig()
 	cfg.EnableRefreshTokens = true
 	cfg.EncryptionKey = testKey
+	cfg.Verbose = true
 	fn := func(no int, req *resty.Request, resp *resty.Response) {
 		if no == 0 {
 			<-time.After(1000 * time.Millisecond)

--- a/misc.go
+++ b/misc.go
@@ -116,10 +116,10 @@ func (r *oauthProxy) redirectToAuthorization(w http.ResponseWriter, req *http.Re
 	return r.revokeProxy(w, req)
 }
 
-// getAccessCookieExpiration calucates the expiration of the access token cookie
+// getAccessCookieExpiration calculates the expiration of the access token cookie
 func (r *oauthProxy) getAccessCookieExpiration(token jose.JWT, refresh string) time.Duration {
 	// notes: by default the duration of the access token will be the configuration option, if
-	// however we can decode the refresh token, we will set the duration to the duraction of the
+	// however we can decode the refresh token, we will set the duration to the duration of the
 	// refresh token
 	duration := r.config.AccessTokenDuration
 	if _, ident, err := parseToken(refresh); err == nil {
@@ -127,6 +127,9 @@ func (r *oauthProxy) getAccessCookieExpiration(token jose.JWT, refresh string) t
 		if delta > 0 {
 			duration = delta
 		}
+		r.log.Debug("parsed refresh token with new duration", zap.Duration("new duration", delta))
+	} else {
+		r.log.Debug("refresh token is opaque and cannot be used to extend calculated duration")
 	}
 
 	return duration


### PR DESCRIPTION
Whenever keycloak is set to revoke refresh tokens after usage, we need to get
the new refresh token, its expiry and refresh the cookie in response.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>