### PR TITLE
Support multiple upstreams

### DIFF
--- a/config.go
+++ b/config.go
@@ -183,10 +183,18 @@ func (r *Config) isValid() error {
 		}
 	} else {
 		if r.Upstream == "" {
-			return errors.New("you have not specified an upstream endpoint to proxy to")
-		}
-		if _, err := url.Parse(r.Upstream); err != nil {
-			return fmt.Errorf("the upstream endpoint is invalid, %s", err)
+			if r.EnableDefaultDeny {
+				return errors.New("you have not specified an upstream endpoint to proxy to")
+			}
+			for _, resource := range r.Resources {
+				if resource.Upstream == "" {
+					return errors.New("you have not specified an upstream endpoint to proxy to")
+				}
+			}
+		} else {
+			if _, err := url.Parse(r.Upstream); err != nil {
+				return fmt.Errorf("the upstream endpoint is invalid, %s", err)
+			}
 		}
 		if r.SkipUpstreamTLSVerify && r.UpstreamCA != "" {
 			return fmt.Errorf("you cannot skip upstream tls and load a root ca: %s to verify it", r.UpstreamCA)

--- a/cors_test.go
+++ b/cors_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2015 All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	e2eCorsUpstreamListener = "127.0.0.1:12345"
+	e2eCorsProxyListener    = "127.0.0.1:54321"
+	e2eCorsOauthListener    = "127.0.0.1:23456"
+
+	e2eCorsUpstreamURL = "/upstream"
+)
+
+func testBuildCorsConfig() *Config {
+	config := newDefaultConfig()
+	config.Listen = e2eCorsProxyListener
+	config.DiscoveryURL = testDiscoveryURL(e2eCorsOauthListener, "master")
+	config.Upstream = "http://" + e2eCorsUpstreamListener
+	config.CorsOrigins = []string{"*"}
+	config.Verbose = false
+	config.EnableLogging = false
+	config.DisableAllLogging = true
+
+	config.Resources = []*Resource{
+		{
+			URL:         e2eCorsUpstreamURL,
+			Methods:     []string{"GET"},
+			WhiteListed: true,
+		},
+	}
+	return config
+}
+
+func TestCorsWithUpstream(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	config := testBuildCorsConfig()
+
+	// launch fake upstream resource server
+	_ = runTestUpstream(t, e2eCorsUpstreamListener, e2eCorsUpstreamURL)
+
+	// launch fake oauth OIDC server
+	_ = runTestAuth(t, e2eCorsOauthListener, "master")
+
+	// launch keycloak-gatekeeper proxy
+	_ = runTestGatekeeper(t, config)
+
+	// ok now exercise the ensemble with a CORS-enabled request
+	client := http.Client{}
+	u, _ := url.Parse("http://" + e2eCorsProxyListener + e2eCorsUpstreamURL)
+	h := make(http.Header, 1)
+	h.Set("Content-Type", "application/json")
+	h.Add("Origin", "myorigin.com")
+
+	resp, err := client.Do(&http.Request{
+		Method: "GET",
+		URL:    u,
+		Header: h,
+	})
+	assert.NoError(t, err)
+	buf, erb := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, erb)
+	assert.Contains(t, string(buf), `"message": "test"`) // check this is our test resource
+	if assert.NotEmpty(t, resp.Header) && assert.Contains(t, resp.Header, "Access-Control-Allow-Origin") {
+		// check the returned upstream response after proxying contains CORS headers
+		assert.Equal(t, []string{"*"}, resp.Header["Access-Control-Allow-Origin"])
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -149,6 +149,12 @@ type Resource struct {
 	Groups []string `json:"groups" yaml:"groups"`
 	// EnableCSRF enables CSRF check on this upstream Resource
 	EnableCSRF bool `json:"enable-csrf" yaml:"enable-csrf"`
+	// StripBasePath is the prefix to strip from URL before sending upstream
+	StripBasePath string `json:"strip-basepath" yaml:"strip-basepath"`
+	// Upstream is the upstream endpoint i.e whom were proxying to
+	Upstream string `json:"upstream-url" yaml:"upstream-url" usage:"url for the upstream endpoint you wish to proxy this resource"`
+	// TODO: UpstreamCA is the path to a CA certificate in PEM format to validate the upstream certificate
+	//UpstreamCA string `json:"upstream-ca" yaml:"upstream-ca" usage:"the path to a file container a CA certificate to validate the upstream tls endpoint for this resource"`
 }
 
 // Config is the configuration for the proxy
@@ -213,6 +219,7 @@ type Config struct {
 	EnableLogoutRedirect bool `json:"enable-logout-redirect" yaml:"enable-logout-redirect" usage:"indicates we should redirect to the identity provider for logging out"`
 	// EnableDefaultDeny indicates we should deny by default all requests
 	EnableDefaultDeny bool `json:"enable-default-deny" yaml:"enable-default-deny" usage:"enables a default denial on all requests, you have to explicitly say what is permitted (recommended)"`
+	// Enable... TODO(fredbi) : explicit resources
 	// EnableEncryptedToken indicates the access token should be encoded
 	EnableEncryptedToken bool `json:"enable-encrypted-token" yaml:"enable-encrypted-token" usage:"enable encryption for the access tokens"`
 	// ForceEncryptedCookie indicates that the access token in the cookie should be encoded, regardless what EnableEncryptedToken says. This way, gatekeeper may receive tokens in header in the clear, whereas tokens in cookies remain encrypted

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -16,10 +16,11 @@ limitations under the License.
 package main
 
 import (
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -27,14 +28,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-)
-
-const (
-	e2eUpstreamURL      = "/upstream"
-	e2eUpstreamListener = "127.0.0.1:12345"
-	e2eProxyListener    = "127.0.0.1:54321"
-	e2eOauthListener    = "127.0.0.1:23456"
-	e2eOauthURL         = "/.well-known/openid-configuration"
 )
 
 // checkListenOrBail waits on a endpoint listener to respond.
@@ -67,98 +60,218 @@ func runTestGatekeeper(t *testing.T, config *Config) error {
 		t.FailNow()
 		return err
 	}
+	t.Logf("test proxy gatekeeper: %s", config.Listen)
 	return nil
 }
 
-func runTestUpstream(t *testing.T) error {
+func runTestUpstream(t *testing.T, listener, route string, markers ...string) error {
 	go func() {
 		upstreamHandler := func(w http.ResponseWriter, req *http.Request) {
-			_, _ = io.WriteString(w, `{"message": "test"}`)
+			_, _ = io.WriteString(w, `{"listener": "`+listener+`", "route": "`+route+`", "message": "test"`)
+			for _, m := range markers {
+				_, _ = io.WriteString(w, `,"marker": "`+m+`"`)
+			}
+			_, _ = io.WriteString(w, `}`)
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("X-Upstream-Response-Header", "test")
 		}
-		http.HandleFunc(e2eUpstreamURL, upstreamHandler)
-		_ = http.ListenAndServe(e2eUpstreamListener, nil)
+		http.HandleFunc(route, upstreamHandler)
+		_ = http.ListenAndServe(listener, nil)
 	}()
-	if !assert.True(t, checkListenOrBail("http://"+path.Join(e2eUpstreamListener, e2eUpstreamURL))) {
-		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+path.Join(e2eUpstreamListener, e2eUpstreamURL))
+	if !assert.True(t, checkListenOrBail("http://"+path.Join(listener, route))) {
+		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+path.Join(listener, route))
 		t.Logf("%v", err)
 		t.FailNow()
 		return err
 	}
+	t.Logf("test upstream server: %s%s", listener, route)
 	return nil
 }
 
-func runTestAuth(t *testing.T) error {
+func runTestApp(t *testing.T, listener, route string) error {
 	go func() {
+		mux := http.NewServeMux()
+		appHandler := func(w http.ResponseWriter, req *http.Request) {
+			_, _ = io.WriteString(w, `{"message": "ok"}`)
+			w.Header().Set("Content-Type", "application/json")
+		}
+		mux.HandleFunc(route, appHandler)
+		_ = http.ListenAndServe(listener, mux)
+	}()
+	if !assert.True(t, checkListenOrBail("http://"+path.Join(listener, route))) {
+		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+path.Join(listener, route))
+		t.Logf("%v", err)
+		t.FailNow()
+		return err
+	}
+	t.Logf("test app server: %s%s", listener, route)
+	return nil
+}
+
+func testDiscoveryPath(realm string) string {
+	return path.Join("/auth", "realms", realm, ".well-known", "openid-configuration")
+}
+
+func testDiscoveryURL(listener, realm string) string {
+	return "http://" + listener + testDiscoveryPath(realm)
+}
+
+func runTestAuth(t *testing.T, listener, realm string) error {
+	// a stub OIDC provider
+	fake := newFakeAuthServer()
+	fake.location, _ = url.Parse("http://" + listener)
+
+	issuer := "http://" + listener + path.Join("/auth", "realms", realm)
+	discoveryURL := testDiscoveryPath(realm)
+	authorizeURL := path.Join("/auth", "realms", realm, "protocol", "openid-connect", "auth")
+	// #nosec
+	tokenURL := path.Join("/auth", "realms", realm, "protocol", "openid-connect", "token")
+	jwksURL := path.Join("/auth", "realms", realm, "protocol", "openid-connect", "certs")
+
+	go func() {
+		mux := http.NewServeMux()
 		configurationHandler := func(w http.ResponseWriter, req *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{
-				"issuer": "http://`+e2eOauthListener+`",
+				"issuer": "`+issuer+`",
 				"subject_types_supported":["public","pairwise"],
 				"id_token_signing_alg_values_supported":["ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","RS512"],
 				"userinfo_signing_alg_values_supported":["ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","RS512","none"],
-				"authorization_endpoint":"http://`+e2eOauthListener+`/auth/realms/master/protocol/openid-connect/auth",
-				"token_endpoint":"http://`+e2eOauthListener+`/auth/realms/master/protocol/openid-connect/token",
-				"jwks_uri":"http://`+e2eOauthListener+`/auth/realms/master/protocol/openid-connect/certs"
+				"authorization_endpoint":"http://`+listener+authorizeURL+`",
+				"token_endpoint":"http://`+listener+tokenURL+`",
+				"jwks_uri":"http://`+listener+jwksURL+`"
 			}`)
 		}
-		http.HandleFunc(e2eOauthURL, configurationHandler)
-		_ = http.ListenAndServe(e2eOauthListener, nil)
+		authorizeHandler := func(w http.ResponseWriter, req *http.Request) {
+			redirect := req.FormValue("redirect_uri")
+			state := req.FormValue("state")
+			code := "zyx"
+			location, _ := url.PathUnescape(redirect)
+			u, _ := url.Parse(location)
+			v := u.Query()
+			v.Set("code", code)
+			v.Set("state", state)
+			u.RawQuery = v.Encode()
+			http.Redirect(w, req, u.String(), http.StatusFound)
+		}
+
+		tokenHandler := func(w http.ResponseWriter, req *http.Request) {
+			fake.tokenHandler(w, req)
+		}
+
+		keysHandler := func(w http.ResponseWriter, req *http.Request) {
+			fake.keysHandler(w, req)
+		}
+		mux.HandleFunc(discoveryURL, configurationHandler)
+		mux.HandleFunc(authorizeURL, authorizeHandler)
+		mux.HandleFunc(tokenURL, tokenHandler)
+		mux.HandleFunc(jwksURL, keysHandler)
+		_ = http.ListenAndServe(listener, mux)
 	}()
-	if !assert.True(t, checkListenOrBail("http://"+path.Join(e2eOauthListener, e2eOauthURL))) {
-		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+path.Join(e2eOauthListener, e2eOauthURL))
+	if !assert.True(t, checkListenOrBail("http://"+path.Join(listener, jwksURL))) {
+		err := fmt.Errorf("cannot connect to test http listener on: %s", "http://"+path.Join(listener, jwksURL))
 		t.Logf("%v", err)
 		t.FailNow()
 		return err
 	}
+	t.Logf("test auth server: %s [%s]", listener, realm)
 	return nil
 }
 
-func TestCorsWithUpstream(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	config := newDefaultConfig()
-	config.Listen = e2eProxyListener
-	config.DiscoveryURL = "http://" + e2eOauthListener + e2eOauthURL
-	config.Upstream = "http://" + e2eUpstreamListener
-	config.CorsOrigins = []string{"*"}
-	config.Verbose = false
-	config.DisableAllLogging = true
-	config.Resources = []*Resource{
-		{
-			URL:         e2eUpstreamURL,
-			Methods:     []string{"GET"},
-			WhiteListed: true,
+// runTestConnect exercises a connect scenario in which the client gets redirected to
+// an OIDC authorize endpoint, then to the gatekeeper caller, and
+// eventually to a custom endpoint specified in an initial cookie.
+//
+// NOTE: in this scenario, the "state" possibly passed by the initial query
+// is no more carried on til the end of the endshake
+//
+// This scenario mimics a typical browser app running the authentication handshake
+// in an iframe, the calling a custom URL to close the iframe after successful authentication.
+//
+// NOTE: for testing purposes, we use http transport and have to force our test client to
+// forward the expected "request_uri" cookie set by the client.
+func runTestConnect(t *testing.T, config *Config, listener, route string) (string, []*http.Cookie, error) {
+	client := http.Client{
+		Transport: controlledRedirect{
+			CollectedCookies: make(map[string]*http.Cookie, 10),
 		},
+		CheckRedirect: onRedirect,
 	}
+	u, _ := url.Parse("http://" + config.Listen + "/oauth/authorize")
+	v := u.Query()
+	v.Set("state", "my_client_nonce") // NOTE: this state provided by the client is not currently carried on to the end (lost)
+	u.RawQuery = v.Encode()
 
-	// launch fake upstream resource server
-	_ = runTestUpstream(t)
-
-	// launch fake oauth OIDC server
-	_ = runTestAuth(t)
-
-	// launch keycloak-gatekeeper proxy
-	_ = runTestGatekeeper(t, config)
-
-	// ok now exercise the ensemble with a CORS-enabled request
-	client := http.Client{}
-	u, _ := url.Parse("http://" + e2eProxyListener + e2eUpstreamURL)
-	h := make(http.Header, 1)
-	h.Set("Content-Type", "application/json")
-	h.Add("Origin", "myorigin.com")
-
-	resp, err := client.Do(&http.Request{
+	req := &http.Request{
 		Method: "GET",
 		URL:    u,
-		Header: h,
-	})
-	assert.NoError(t, err)
+		Header: make(http.Header),
+	}
+	// add request_uri to specify last stop redirection (inner workings since PR #440)
+	encoded := base64.StdEncoding.EncodeToString([]byte("http://" + listener + route))
+	ck := &http.Cookie{
+		Name:  "request_uri",
+		Value: encoded,
+		Path:  "/",
+		// real life cookie gets Secure, SameSite
+	}
+	req.AddCookie(ck)
+
+	// attempts to login
+	resp, err := client.Do(req)
+	if !assert.NoError(t, err) {
+		return "", nil, err
+	}
+
+	// check that we get the final redirection to app correctly
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	buf, erb := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, erb)
-	assert.JSONEq(t, `{"message":"test"}`, string(buf)) // check this is our test resource
-	if assert.NotEmpty(t, resp.Header) && assert.Contains(t, resp.Header, "Access-Control-Allow-Origin") {
-		// check the returned upstream response after proxying contains CORS headers
-		assert.Equal(t, []string{"*"}, resp.Header["Access-Control-Allow-Origin"])
+	assert.JSONEq(t, `{"message": "ok"}`, string(buf))
+
+	// returns all collected cookies during the handshake
+	collector := client.Transport.(controlledRedirect)
+	collected := make([]*http.Cookie, 0, 10)
+	for _, ck := range collector.CollectedCookies {
+		collected = append(collected, ck)
+	}
+
+	// assert kc-access cookie
+	var (
+		found       bool
+		accessToken string
+	)
+	for _, ck := range collected {
+		if ck.Name == config.CookieAccessName {
+			accessToken = ck.Value
+			found = true
+			break
+		}
+	}
+	assert.True(t, found)
+	if t.Failed() {
+		return "", nil, errors.New("failed to connect")
+	}
+	return accessToken, collected, nil
+}
+
+func getCookie(resp *http.Response, name string) (cookie *http.Cookie) {
+	for _, ck := range resp.Cookies() {
+		if ck.Name == name {
+			cookie = ck
+			break
+		}
+	}
+	return
+}
+
+func copyCookies(req *http.Request, cookies []*http.Cookie) {
+	ckMap := make(map[string]*http.Cookie, len(cookies))
+	for _, ck := range cookies {
+		if ck != nil {
+			ckMap[ck.Name] = ck // dedupe
+			// forward cookies obtained during authentication stage (mimicks browser)
+			req.AddCookie(ckMap[ck.Name])
+		}
 	}
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -378,6 +378,11 @@ func TestMethodExclusions(t *testing.T) {
 			URL:     "/post",
 			Methods: []string{http.MethodPost, http.MethodPut},
 		},
+		{
+			URL:         "/white",
+			WhiteListed: true,
+			Methods:     []string{http.MethodPost, http.MethodPut},
+		},
 	}
 	requests := []fakeRequest{
 		{ // we should get a 401
@@ -385,11 +390,58 @@ func TestMethodExclusions(t *testing.T) {
 			Method:       http.MethodPost,
 			ExpectedCode: http.StatusUnauthorized,
 		},
-		{ // we should be permitted
+		{ // we should be okay
 			URI:           "/post",
-			Method:        http.MethodGet,
+			HasToken:      true,
+			Method:        http.MethodPost,
 			ExpectedProxy: true,
 			ExpectedCode:  http.StatusOK,
+		},
+		{ // we should get a 401
+			URI:          "/post",
+			Method:       http.MethodPut,
+			ExpectedCode: http.StatusUnauthorized,
+		},
+		{ // we should be okay
+			URI:           "/post",
+			HasToken:      true,
+			Method:        http.MethodPut,
+			ExpectedProxy: true,
+			ExpectedCode:  http.StatusOK,
+		},
+		{ // we should NOT be permitted
+			URI:          "/post",
+			HasToken:     true,
+			Method:       http.MethodGet,
+			ExpectedCode: http.StatusMethodNotAllowed,
+		},
+		{ // we should NOT be permitted
+			URI:          "/post",
+			Method:       http.MethodGet,
+			ExpectedCode: http.StatusUnauthorized,
+		},
+		{ // we should NOT be permitted
+			URI:          "/post",
+			HasToken:     true,
+			Method:       http.MethodGet,
+			ExpectedCode: http.StatusMethodNotAllowed,
+		},
+		{ // we should be permitted
+			URI:           "/white",
+			Method:        http.MethodPost,
+			ExpectedProxy: true,
+			ExpectedCode:  http.StatusOK,
+		},
+		{ // we should be permitted
+			URI:           "/white",
+			Method:        http.MethodPut,
+			ExpectedProxy: true,
+			ExpectedCode:  http.StatusOK,
+		},
+		{ // we should NOT be permitted
+			URI:          "/white",
+			Method:       http.MethodGet,
+			ExpectedCode: http.StatusMethodNotAllowed,
 		},
 	}
 	newFakeProxy(cfg).RunTests(t, requests)
@@ -834,8 +886,8 @@ func TestRolePermissionsMiddleware(t *testing.T) {
 			Redirects:     false,
 			HasToken:      true,
 			Roles:         []string{fakeTestRole},
-			ExpectedCode:  http.StatusOK,
-			ExpectedProxy: true,
+			ExpectedCode:  http.StatusMethodNotAllowed,
+			ExpectedProxy: false,
 		},
 		{ // check with correct token
 			URI:           "/test",
@@ -1267,21 +1319,77 @@ func TestAdmissionHandlerRoles(t *testing.T) {
 }
 
 // check to see if custom headers are hitting the upstream
-func TestCustomHeaders(t *testing.T) {
+//
+// When EnableDefaultDeny, URIs not declared as resources are not forwarded.
+func TestCustomHeadersUpstream(t *testing.T) {
 	requests := []struct {
-		Headers map[string]string
-		Request fakeRequest
+		Headers         map[string]string
+		Request         fakeRequest
+		WithDefaultDeny bool
 	}{
 		{
+			// this one does not pass proxy: it is not even authorized
 			Headers: map[string]string{
 				"TestHeaderOne": "one",
 			},
 			Request: fakeRequest{
-				URI:           "/gambol99.htm",
-				ExpectedProxy: true,
-				ExpectedProxyHeaders: map[string]string{
-					"TestHeaderOne": "one",
-				},
+				URI:                  "/gambol99.htm",
+				ExpectedProxyHeaders: map[string]string{},
+				ExpectedCode:         http.StatusUnauthorized,
+				ExpectedProxy:        false,
+			},
+			WithDefaultDeny: true,
+		},
+		{
+			// this one does pass proxy: the request is authenticated
+			Headers: map[string]string{
+				"TestHeaderOne": "one",
+			},
+			Request: fakeRequest{
+				URI:                  "/fred",
+				HasToken:             true,
+				ExpectedProxyHeaders: map[string]string{},
+				ExpectedCode:         http.StatusOK,
+				ExpectedProxy:        true,
+			},
+			WithDefaultDeny: true,
+		},
+		{
+			// this one does pass proxy
+			Headers: map[string]string{
+				"TestHeaderOne": "one",
+			},
+			Request: fakeRequest{
+				URI:                  "/gambol99.htm",
+				ExpectedProxyHeaders: map[string]string{},
+				ExpectedCode:         http.StatusOK,
+				ExpectedProxy:        true,
+			},
+			WithDefaultDeny: false,
+		},
+		{
+			// this one does pass proxy
+			Headers: map[string]string{
+				"TestHeaderOne": "one",
+			},
+			Request: fakeRequest{
+				URI:                  "/fred/sneak/attempt",
+				ExpectedProxyHeaders: map[string]string{},
+				ExpectedCode:         http.StatusOK,
+				ExpectedProxy:        true,
+			},
+			WithDefaultDeny: false,
+		},
+		{
+			Headers: map[string]string{
+				"TestHeader": "test",
+			},
+			Request: fakeRequest{
+				URI:                  testAdminURI,
+				HasToken:             false,
+				ExpectedProxy:        false,
+				ExpectedProxyHeaders: map[string]string{},
+				ExpectedCode:         http.StatusUnauthorized,
 			},
 		},
 		{
@@ -1295,6 +1403,7 @@ func TestCustomHeaders(t *testing.T) {
 				ExpectedProxyHeaders: map[string]string{
 					"TestHeader": "test",
 				},
+				ExpectedCode: http.StatusOK,
 			},
 		},
 		{
@@ -1310,13 +1419,16 @@ func TestCustomHeaders(t *testing.T) {
 					"TestHeaderOne": "one",
 					"TestHeaderTwo": "two",
 				},
+				ExpectedCode: http.StatusOK,
 			},
 		},
 	}
-	for _, c := range requests {
+	for i, c := range requests {
 		cfg := newFakeKeycloakConfig()
 		cfg.Resources = []*Resource{{URL: "/admin*", Methods: allHTTPMethods}}
 		cfg.Headers = c.Headers
+		cfg.EnableDefaultDeny = c.WithDefaultDeny
+		t.Logf("HeadersUpstream testcase: %d", i)
 		newFakeProxy(cfg).RunTests(t, []fakeRequest{c.Request})
 	}
 }

--- a/resource.go
+++ b/resource.go
@@ -18,6 +18,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -88,6 +89,11 @@ func (r *Resource) valid() error {
 	}
 	if strings.HasSuffix(r.URL, "/") && !r.WhiteListed {
 		return fmt.Errorf("you need a wildcard on the url resource to cover all request i.e. --resources=uri=%s*", r.URL)
+	}
+	if r.Upstream != "" {
+		if _, err := url.Parse(r.Upstream); err != nil {
+			return fmt.Errorf("upstream specified for resource %s is not a valid URL: %q", r.URL, r.Upstream)
+		}
 	}
 
 	// step: add any of no methods

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2015 All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/rs/cors"
+	"go.uber.org/zap"
+)
+
+// createReverseProxy creates a reverse proxy
+func (r *oauthProxy) createReverseProxy() error {
+	r.log.Info("enabled reverse proxy mode, default upstream url", zap.String("url", r.config.Upstream))
+	if err := r.createUpstreamProxy(r.endpoint); err != nil {
+		return err
+	}
+	engine := chi.NewRouter()
+	r.useDefaultStack(engine)
+
+	// @step: configure CORS middleware
+	if len(r.config.CorsOrigins) > 0 {
+		c := cors.New(cors.Options{
+			AllowedOrigins:   r.config.CorsOrigins,
+			AllowedMethods:   r.config.CorsMethods,
+			AllowedHeaders:   r.config.CorsHeaders,
+			AllowCredentials: r.config.CorsCredentials,
+			ExposedHeaders:   r.config.CorsExposedHeaders,
+			MaxAge:           int(r.config.CorsMaxAge.Seconds()),
+			Debug:            r.config.Verbose,
+		})
+		engine.Use(c.Handler)
+	}
+
+	r.router = engine
+
+	if len(r.config.ResponseHeaders) > 0 {
+		engine.Use(r.responseHeaderMiddleware(r.config.ResponseHeaders))
+	}
+
+	// configure CSRF middleware
+	r.csrf = r.csrfConfigMiddleware()
+
+	// step: define admin subrouter: health and metrics
+	adminEngine := chi.NewRouter()
+	r.log.Info("enabled health service", zap.String("path", path.Clean(r.config.WithOAuthURI(healthURL))))
+	adminEngine.Get(healthURL, r.healthHandler)
+	if r.config.EnableMetrics {
+		r.log.Info("enabled the service metrics middleware", zap.String("path", path.Clean(r.config.WithOAuthURI(metricsURL))))
+		adminEngine.Get(metricsURL, r.proxyMetricsHandler)
+	}
+
+	// step: add the routing for oauth
+	engine.With(
+		proxyDenyMiddleware,
+		r.csrfSkipMiddleware(), // handle CSRF state, but skip check on POST endpoints below
+		r.csrfProtectMiddleware(),
+		r.csrfHeaderMiddleware()).Route(r.config.OAuthURI, func(e chi.Router) {
+		e.MethodNotAllowed(methodNotAllowHandlder)
+		e.HandleFunc(authorizationURL, r.oauthAuthorizationHandler)
+		e.Get(callbackURL, r.oauthCallbackHandler)
+		e.Get(expiredURL, r.expirationHandler)
+
+		e.With(r.authenticationMiddleware()).Get(logoutURL, r.logoutHandler)
+		e.With(r.authenticationMiddleware()).Get(tokenURL, r.tokenHandler)
+
+		e.Post(loginURL, r.loginHandler)
+
+		if r.config.ListenAdmin == "" {
+			e.Mount("/", adminEngine)
+		}
+	})
+
+	// step: define profiling subrouter
+	var debugEngine chi.Router
+	if r.config.EnableProfiling {
+		r.log.Warn("enabling the debug profiling on " + debugURL)
+		debugEngine = chi.NewRouter()
+		debugEngine.Get("/{name}", r.debugHandler)
+		debugEngine.Post("/{name}", r.debugHandler)
+
+		// @check if the server write-timeout is still set and throw a warning
+		if r.config.ServerWriteTimeout > 0 {
+			r.log.Warn("you should disable the server write timeout (--server-write-timeout) when using pprof profiling")
+		}
+		if r.config.ListenAdmin == "" {
+			engine.With(proxyDenyMiddleware).Mount(debugURL, debugEngine)
+		}
+	}
+
+	if r.config.ListenAdmin != "" {
+		// mount admin and debug engines separately
+		r.log.Info("mounting admin endpoints on separate listener")
+		admin := chi.NewRouter()
+		admin.MethodNotAllowed(emptyHandler)
+		admin.NotFound(emptyHandler)
+		admin.Use(middleware.Recoverer)
+		admin.Use(proxyDenyMiddleware)
+		admin.Route("/", func(e chi.Router) {
+			e.Mount(r.config.OAuthURI, adminEngine)
+			if debugEngine != nil {
+				e.Mount(debugURL, debugEngine)
+			}
+		})
+		r.adminRouter = admin
+	}
+
+	if r.config.EnableSessionCookies {
+		r.log.Info("using session cookies only for access and refresh tokens")
+	}
+
+	// step: load the templates if any
+	if err := r.createTemplates(); err != nil {
+		return err
+	}
+	// step: provision in the protected resources
+	enableDefaultDeny := r.config.EnableDefaultDeny
+	for _, x := range r.config.Resources {
+		if x.URL[len(x.URL)-1:] == "/" {
+			r.log.Warn("the resource url is not a prefix",
+				zap.String("resource", x.URL),
+				zap.String("change", x.URL),
+				zap.String("amended", strings.TrimRight(x.URL, "/")))
+		}
+		if x.URL == "/*" && r.config.EnableDefaultDeny {
+			switch x.WhiteListed {
+			case true:
+				return errors.New("you've asked for a default denial but whitelisted everything")
+			default:
+				enableDefaultDeny = false
+			}
+		}
+	}
+
+	if enableDefaultDeny {
+		r.log.Info("adding a default denial to protected resources: all routes to upstream require authentication")
+		r.config.Resources = append(r.config.Resources, &Resource{URL: "/*", Methods: allHTTPMethods})
+	} else {
+		r.log.Info("routes to upstream are not configured to be denied by default")
+		engine.With(r.proxyMiddleware(nil)).HandleFunc("/*", emptyHandler)
+	}
+
+	for _, x := range r.config.Resources {
+		r.log.Info("protecting resource", zap.String("resource", x.String()))
+		if !x.WhiteListed {
+			e := engine.With(
+				r.proxyMiddleware(x),
+				r.authenticationMiddleware(),
+				r.admissionMiddleware(x),
+				r.identityHeadersMiddleware(r.config.AddClaims),
+				r.csrfSkipResourceMiddleware(x),
+				r.csrfProtectMiddleware(),
+				r.csrfHeaderMiddleware())
+			e.Handle(x.URL, chi.NewMux().MethodNotAllowedHandler())
+			for _, m := range x.Methods {
+				e.MethodFunc(m, x.URL, emptyHandler)
+			}
+		} else {
+			e := engine.With(
+				r.proxyMiddleware(x))
+			e.Handle(x.URL, chi.NewMux().MethodNotAllowedHandler())
+			for _, m := range x.Methods {
+				e.MethodFunc(m, x.URL, emptyHandler)
+			}
+		}
+	}
+
+	for name, value := range r.config.MatchClaims {
+		r.log.Info("token must contain", zap.String("claim", name), zap.String("value", value))
+	}
+	if r.config.RedirectionURL == "" {
+		r.log.Warn("no redirection url has been set, will use host headers")
+	}
+	if r.config.EnableEncryptedToken {
+		r.log.Info("session access tokens will be encrypted")
+	}
+
+	return nil
+}
+
+// proxyMiddleware is responsible for handles reverse proxy request to the upstream endpoint
+func (r *oauthProxy) proxyMiddleware(resource *Resource) func(http.Handler) http.Handler {
+	var upstreamHost, upstreamScheme, upstreamBasePath, stripBasePath, matched string
+	if resource != nil && resource.Upstream != "" {
+		// resource-specific routing to upstream
+		u, _ := url.Parse(resource.Upstream)
+		matched = resource.URL
+		upstreamHost = u.Host
+		upstreamScheme = u.Scheme
+		upstreamBasePath = u.Path
+	} else {
+		// default routing
+		upstreamHost = r.endpoint.Host
+		upstreamScheme = r.endpoint.Scheme
+		upstreamBasePath = r.endpoint.Path
+	}
+	if resource != nil {
+		stripBasePath = resource.StripBasePath
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			next.ServeHTTP(w, req)
+
+			// @step: retrieve the request scope
+			scope := req.Context().Value(contextScopeName)
+			if scope != nil {
+				sc := scope.(*RequestScope)
+				if sc.AccessDenied {
+					return
+				}
+			}
+
+			// @step: add the proxy forwarding headers
+			req.Header.Add("X-Forwarded-For", realIP(req))
+			req.Header.Set("X-Forwarded-Host", req.Host)
+			req.Header.Set("X-Forwarded-Proto", req.Header.Get("X-Forwarded-Proto"))
+
+			if len(r.config.CorsOrigins) > 0 {
+				// if CORS is enabled by gatekeeper, do not propagate CORS requests upstream
+				req.Header.Del("Origin")
+			}
+			// @step: add any custom headers to the request
+			for k, v := range r.config.Headers {
+				req.Header.Set(k, v)
+			}
+
+			if r.config.EnableCSRF {
+				// remove csrf header
+				req.Header.Del(r.config.CSRFHeader)
+				if !r.config.EnableAuthorizationCookies {
+					_ = filterCookies(req, []string{requestURICookie, r.config.CSRFCookieName})
+				}
+			} else if !r.config.EnableAuthorizationCookies {
+				_ = filterCookies(req, []string{requestURICookie})
+			}
+
+			req.URL.Host = upstreamHost
+			req.URL.Scheme = upstreamScheme
+			if stripBasePath != "" {
+				// strip prefix if needed
+				req.URL.Path = strings.TrimPrefix(stripBasePath, req.URL.Path)
+			}
+			if upstreamBasePath != "" {
+				// add upstream URL component if any
+				req.URL.Path = path.Join(upstreamBasePath, req.URL.Path)
+			}
+			r.log.Debug("proxying to upstream", zap.String("matched_resource", matched), zap.Stringer("upstream_url", req.URL))
+
+			// @note: by default goproxy only provides a forwarding proxy, thus all requests have to be absolute and we must update the host headers
+			// TODO(fredbi): weakness here
+			if v := req.Header.Get("Host"); v != "" {
+				req.Host = v
+				req.Header.Del("Host")
+			} else if !r.config.PreserveHost {
+				req.Host = upstreamHost
+			}
+			r.log.Debug("host", zap.String("host", req.Host))
+
+			if isUpgradedConnection(req) {
+				r.log.Debug("upgrading the connnection", zap.String("client_ip", req.RemoteAddr))
+				if err := tryUpdateConnection(req, w, req.URL); err != nil {
+					r.log.Error("failed to upgrade connection", zap.Error(err))
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				return
+			}
+
+			r.upstream.ServeHTTP(w, req)
+		})
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -523,6 +523,7 @@ type fakeUpstreamResponse struct {
 	Method  string      `json:"method"`
 	Address string      `json:"address"`
 	Headers http.Header `json:"headers"`
+	Message string      `json:"message"`
 }
 
 // fakeUpstreamService acts as a fake upstream service, returns the headers and request
@@ -537,6 +538,7 @@ func (f *fakeUpstreamService) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Method:  r.Method,
 		Address: r.RemoteAddr,
 		Headers: r.Header,
+		Message: "upstream called",
 	})
 	_, _ = w.Write(content)
 }

--- a/upstreams_test.go
+++ b/upstreams_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2015 All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	e2eUpstreamsProxyListener = "127.0.0.1:23329"
+
+	e2eUpstreamsOauthListener     = "127.0.0.1:13457"
+	e2eUpstreamsUpstreamListener1 = "127.0.0.1:18512"
+	e2eUpstreamsUpstreamListener2 = "127.0.0.1:8512"
+	e2eUpstreamsUpstreamListener3 = "127.0.0.1:7512"
+
+	e2eUpstreamsAppListener  = "127.0.0.1:3996"
+	e2eUpstreamsAppURL       = "/ok"
+	e2eUpstreamsUpstreamURL1 = "/api1"
+	e2eUpstreamsUpstreamURL2 = "/api2"
+	e2eUpstreamsUpstreamURL3 = "/api3"
+)
+
+func testBuildUpstreamsConfig() *Config {
+	config := newDefaultConfig()
+	config.Verbose = true
+	config.EnableLogging = true
+	config.DisableAllLogging = false
+
+	config.Listen = e2eUpstreamsProxyListener
+	config.DiscoveryURL = testDiscoveryURL(e2eUpstreamsOauthListener, "hod-test")
+
+	config.Upstream = "http://" + e2eUpstreamsUpstreamListener3
+
+	config.CorsOrigins = []string{"*"}
+	config.EnableCSRF = false
+	config.HTTPOnlyCookie = false // since we want to inspect the cookie for testing
+	config.SecureCookie = false   // since we are testing over HTTP
+	config.AccessTokenDuration = 30 * time.Minute
+	config.EnableEncryptedToken = false
+	config.EnableSessionCookies = true
+	config.EnableAuthorizationCookies = false
+	config.EnableClaimsHeaders = false
+	config.EnableTokenHeader = false
+	config.EnableAuthorizationHeader = true
+	config.ClientID = fakeClientID
+	config.ClientSecret = fakeSecret
+	config.Resources = []*Resource{
+		{
+			URL:           "/fake",
+			Methods:       []string{"GET", "POST", "DELETE"},
+			WhiteListed:   false,
+			EnableCSRF:    false,
+			Upstream:      "http://" + e2eUpstreamsUpstreamListener1 + e2eUpstreamsUpstreamURL1,
+			StripBasePath: "/fake",
+		},
+	}
+	config.Resources = append(config.Resources, &Resource{
+		URL:         "/another-fake",
+		Methods:     []string{"GET", "POST", "DELETE"},
+		WhiteListed: false,
+		EnableCSRF:  false,
+		Upstream:    "http://" + e2eUpstreamsUpstreamListener2 + e2eUpstreamsUpstreamURL2,
+	})
+	config.Resources = append(config.Resources, &Resource{
+		URL:         "/again-a-fake",
+		Methods:     []string{"GET", "POST", "DELETE"},
+		WhiteListed: false,
+		EnableCSRF:  false,
+	})
+	config.EncryptionKey = secretForCookie
+	return config
+}
+
+func TestUpstreams(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	config := testBuildUpstreamsConfig()
+	require.NoError(t, config.isValid())
+
+	// launch fake oauth OIDC server
+	err := runTestAuth(t, e2eUpstreamsOauthListener, "hod-test")
+	require.NoError(t, err)
+
+	// launch fake upstream resource serverS
+	err = runTestUpstream(t, e2eUpstreamsUpstreamListener1, e2eUpstreamsUpstreamURL1, "mark1")
+	require.NoError(t, err)
+
+	err = runTestUpstream(t, e2eUpstreamsUpstreamListener2, e2eUpstreamsUpstreamURL2+"/another-fake", "mark2")
+	require.NoError(t, err)
+
+	err = runTestUpstream(t, e2eUpstreamsUpstreamListener3, e2eUpstreamsUpstreamURL3, "mark3")
+	require.NoError(t, err)
+
+	// launch fake app server where to land after authentication
+	err = runTestApp(t, e2eUpstreamsAppListener, e2eUpstreamsAppURL)
+	require.NoError(t, err)
+
+	// launch keycloak-gatekeeper proxy
+	err = runTestGatekeeper(t, config)
+	require.NoError(t, err)
+
+	// establish an authenticated session
+	accessToken, cookies, err := runTestConnect(t, config, e2eUpstreamsAppListener, e2eUpstreamsAppURL)
+	require.NoErrorf(t, err, "could not login: %v", err)
+	require.NotEmpty(t, accessToken)
+
+	// scenario 1: routing to different upstreams
+	client := http.Client{}
+	h := make(http.Header, 10)
+	h.Set("Content-Type", "application/json")
+	h.Add("Accept", "application/json")
+
+	// test upstream 1
+	u, _ := url.Parse("http://" + e2eUpstreamsProxyListener + "/fake")
+	req := &http.Request{
+		Method: "GET",
+		URL:    u,
+		Header: h,
+	}
+	copyCookies(req, cookies)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	buf, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(buf), "mark1")
+	t.Logf(string(buf))
+
+	// test upstream 2
+	u, _ = url.Parse("http://" + e2eUpstreamsProxyListener + "/another-fake")
+	req = &http.Request{
+		Method: "GET",
+		URL:    u,
+		Header: h,
+	}
+	copyCookies(req, cookies)
+
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	buf, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(buf), "mark2")
+	t.Logf(string(buf))
+
+	// test upstream 3
+	u, _ = url.Parse("http://" + e2eUpstreamsProxyListener + e2eUpstreamsUpstreamURL3)
+	req = &http.Request{
+		Method: "GET",
+		URL:    u,
+		Header: h,
+	}
+	copyCookies(req, cookies)
+
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	buf, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(buf), "mark3")
+	t.Logf(string(buf))
+
+	// this should route to {listener3}/api2 and returns 404
+	u, _ = url.Parse("http://" + e2eUpstreamsProxyListener + e2eUpstreamsUpstreamURL2)
+	req = &http.Request{
+		Method: "GET",
+		URL:    u,
+		Header: h,
+	}
+	copyCookies(req, cookies)
+
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	// scenario 2: more basepath & path stripping
+}


### PR DESCRIPTION
* Upstream per resource (global upstream as default)
* Upstream (global or resource) may be an URL with path: will be prepended to request path
* Upstream (resource) may specify the prefix to strip on incoming request

Ex:
* resource URL: /api/path
* upstream: https://localhost/prepend
* stripped: /api

* incoming: https://api/path/resource
* routed to: https://localhost/prepend/path/resource

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>
WIP:
* [ ] integration tests

Fixes #14 