### PR TITLE
Content type on errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go mod download
 
 ADD . /gatekeeper
 RUN LDFLAGS="-s -w -linkmode external -extldflags \"-static\"" &&\
-    go build -o /stage/usr/bin/gatekeeper --ldflags "$LDFLAGS" .
+    go build -tags "nostores noforwarding" -o /stage/usr/bin/gatekeeper --ldflags "$LDFLAGS" .
 RUN upx /stage/usr/bin/gatekeeper
 
 # Build the dist image

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Protected resources (URIs) may be guarded with some basic RBAC rules checking gr
 
 > NOTE: group rules support trailing wildcards, so you may configure group claims to be the full group hierarchical path.
 
-
 ### Features
 
 * Proxied access token exchange flow
@@ -55,7 +54,6 @@ Protected resources (URIs) may be guarded with some basic RBAC rules checking gr
 * Large cookies are split in chunks
 * When authenticating with cookies, an automatic CSRF mechanism may be used for additional protection
 * Access tokens managed by cookies are refreshed automatically
-
 
 ### Topology
 
@@ -71,8 +69,19 @@ are shared by all instances.
 
 Gatekeeper exposes prometheus metrics and health status endpoint.
 
+```
+/oauth/metrics
+/oauth/health
+```
+
 These may be optionally exposed on a separate port, or restricted to localhost requests.
 
+There is an opt-in live profiler endpoint for debugging performance issues:
+```
+/debug/pprof/{name}
+```
+
+This serves commands from the pprof handler described [here](https://golang.org/pkg/net/http/pprof/#pkg-index).
 
 Reporting security vulnerabilities
 ----------------------------------

--- a/admin_test.go
+++ b/admin_test.go
@@ -139,7 +139,7 @@ func TestAdmin(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	buf, erb := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, erb)
-	assert.Equal(t, "OK\n", string(buf)) // check this is our test resource being called
+	assert.Equal(t, `{"status":"OK"}`, string(buf)) // check this is our test resource being called
 
 	// test prometheus metrics endpoint
 	u, _ = url.Parse("http://" + e2eAdminEndpointListener + "/oauth/metrics")

--- a/config.go
+++ b/config.go
@@ -347,28 +347,6 @@ func (r *Config) isTLSValid() error {
 	return nil
 }
 
-func (r *Config) isForwardingValid() error {
-	if r.ClientID == "" {
-		return errors.New("you have not specified the client id")
-	}
-	if err := r.isDiscoveryValid(); err != nil {
-		return err
-	}
-	if r.ForwardingUsername == "" {
-		return errors.New("no forwarding username")
-	}
-	if r.ForwardingPassword == "" {
-		return errors.New("no forwarding password")
-	}
-	if r.TLSCertificate != "" {
-		return errors.New("you don't need to specify a tls-certificate, use tls-ca-certificate instead")
-	}
-	if r.TLSPrivateKey != "" {
-		return errors.New("you don't need to specify the tls-private-key, use tls-ca-key instead")
-	}
-	return nil
-}
-
 func (r *Config) isReverseProxyValid() error {
 	if r.Upstream == "" {
 		if r.EnableDefaultDeny && !r.EnableDefaultNotFound {
@@ -475,6 +453,7 @@ func (r *Config) isTokenConfigValid() error {
 			return errors.New("the security filter must be switched on for this feature: hostnames")
 		}
 	}
+
 	if (r.EnableEncryptedToken || r.ForceEncryptedCookie) && r.EncryptionKey == "" {
 		return errors.New("you have not specified an encryption key for encoding the access token")
 	}
@@ -487,10 +466,9 @@ func (r *Config) isTokenConfigValid() error {
 	if !r.NoRedirects && r.SecureCookie && r.RedirectionURL != "" && !strings.HasPrefix(r.RedirectionURL, "https") {
 		return errors.New("the cookie is set to secure but your redirection url is non-tls")
 	}
-	if r.StoreURL != "" {
-		if _, err := url.Parse(r.StoreURL); err != nil {
-			return fmt.Errorf("the store url is invalid, error: %s", err)
-		}
+
+	if err := r.isStoreValid(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/doc.go
+++ b/doc.go
@@ -71,6 +71,7 @@ const (
 	secureScheme       = "https"
 	anyMethod          = "ANY"
 	allRoutes          = "/*"
+	jsonMime           = "application/json; charset=utf-8"
 
 	_ contextKey = iota
 	contextScopeName

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+func methodNotAllowedHandler(w http.ResponseWriter, req *http.Request) {
+	errorResponse(w, "", http.StatusMethodNotAllowed)
+	_, _ = w.Write(nil)
+}
+
+func methodNotFoundHandler(w http.ResponseWriter, req *http.Request) {
+	errorResponse(w, "", http.StatusNotFound)
+	_, _ = w.Write(nil)
+}
+
+func (r *oauthProxy) errorResponse(w http.ResponseWriter, msg string, code int, err error) {
+	if err == nil {
+		r.log.Warn(msg, zap.Int("http_status", code))
+	} else {
+		if code == http.StatusInternalServerError {
+			// we log internal server errors as ERRROR
+			r.log.Error(msg, zap.Int("http_status", code), zap.Error(err))
+		} else {
+			// we log user errors as WARNING
+			r.log.Warn(msg, zap.Int("http_status", code), zap.Error(err))
+		}
+	}
+	errorResponse(w, msg, code)
+}
+
+func errorResponse(w http.ResponseWriter, msg string, code int) {
+	w.Header().Set("Content-Type", jsonMime)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	if len(msg) > 0 {
+		fmt.Fprintln(w, fmt.Sprintf(`{%q}`, msg))
+	}
+}
+
+// accessForbidden redirects the user to the forbidden page
+func (r *oauthProxy) accessForbidden(w http.ResponseWriter, req *http.Request, msgs ...string) context.Context {
+	// are we using a custom http template for 403?
+	if r.config.hasCustomForbiddenPage() {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusForbidden)
+		name := path.Base(r.config.ForbiddenPage)
+		if err := r.Render(w, name, r.config.Tags); err != nil {
+			r.log.Error("failed to render the template", zap.Error(err), zap.String("template", name))
+		}
+	} else {
+		var msg string
+		if len(msgs) > 0 {
+			msg = msgs[0]
+			if len(msgs) > 1 {
+				// extraMsg goes to log but not to return end user error
+				extraMsg := strings.Join(msgs[1:], " ")
+				r.log.Warn(extraMsg)
+			}
+		}
+		r.errorResponse(w, msg, http.StatusForbidden, nil)
+	}
+	return r.revokeProxy(w, req)
+}

--- a/forwarding.go
+++ b/forwarding.go
@@ -1,3 +1,5 @@
+//+build !noforwarding
+
 /*
 Copyright 2015 All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +18,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -25,6 +28,28 @@ import (
 	"github.com/elazarl/goproxy"
 	"go.uber.org/zap"
 )
+
+func (r *Config) isForwardingValid() error {
+	if r.ClientID == "" {
+		return errors.New("you have not specified the client id")
+	}
+	if err := r.isDiscoveryValid(); err != nil {
+		return err
+	}
+	if r.ForwardingUsername == "" {
+		return errors.New("no forwarding username")
+	}
+	if r.ForwardingPassword == "" {
+		return errors.New("no forwarding password")
+	}
+	if r.TLSCertificate != "" {
+		return errors.New("you don't need to specify a tls-certificate, use tls-ca-certificate instead")
+	}
+	if r.TLSPrivateKey != "" {
+		return errors.New("you don't need to specify the tls-private-key, use tls-ca-key instead")
+	}
+	return nil
+}
 
 // createForwardingProxy creates a forwarding proxy
 func (r *oauthProxy) createForwardingProxy() error {

--- a/handlers.go
+++ b/handlers.go
@@ -59,8 +59,7 @@ func (r *oauthProxy) getRedirectionURL(w http.ResponseWriter, req *http.Request)
 
 	state, _ := req.Cookie(requestStateCookie)
 	if state != nil && req.URL.Query().Get("state") != state.Value {
-		r.log.Error("state parameter mismatch")
-		w.WriteHeader(http.StatusForbidden)
+		r.errorResponse(w, "state parameter mismatch", http.StatusForbidden, nil)
 		return ""
 	}
 	return fmt.Sprintf("%s%s", redirect, r.config.WithOAuthURI("callback"))
@@ -69,13 +68,12 @@ func (r *oauthProxy) getRedirectionURL(w http.ResponseWriter, req *http.Request)
 // oauthAuthorizationHandler is responsible for performing the redirection to oauth provider
 func (r *oauthProxy) oauthAuthorizationHandler(w http.ResponseWriter, req *http.Request) {
 	if r.config.SkipTokenVerification {
-		w.WriteHeader(http.StatusNotAcceptable)
+		r.errorResponse(w, "", http.StatusNotAcceptable, nil)
 		return
 	}
 	client, err := r.getOAuthClient(r.getRedirectionURL(w, req))
 	if err != nil {
-		r.log.Error("failed to retrieve the oauth client for authorization", zap.Error(err))
-		w.WriteHeader(http.StatusInternalServerError)
+		r.errorResponse(w, "failed to retrieve the oauth client for authorization", http.StatusInternalServerError, err)
 		return
 	}
 
@@ -95,6 +93,7 @@ func (r *oauthProxy) oauthAuthorizationHandler(w http.ResponseWriter, req *http.
 	if r.config.hasCustomSignInPage() {
 		model := make(map[string]string)
 		model["redirect"] = authURL
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		_ = r.Render(w, path.Base(r.config.SignInPage), mergeMaps(model, r.config.Tags))
 
@@ -107,27 +106,25 @@ func (r *oauthProxy) oauthAuthorizationHandler(w http.ResponseWriter, req *http.
 // oauthCallbackHandler is responsible for handling the response from oauth service
 func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Request) {
 	if r.config.SkipTokenVerification {
-		w.WriteHeader(http.StatusNotAcceptable)
+		r.errorResponse(w, "", http.StatusNotAcceptable, nil)
 		return
 	}
 	// step: ensure we have a authorization code
 	code := req.URL.Query().Get("code")
 	if code == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		r.errorResponse(w, "no code in query", http.StatusBadRequest, nil)
 		return
 	}
 
 	client, err := r.getOAuthClient(r.getRedirectionURL(w, req))
 	if err != nil {
-		r.log.Error("unable to create a oauth2 client", zap.Error(err))
-		w.WriteHeader(http.StatusInternalServerError)
+		r.errorResponse(w, "unable to create a oauth2 client", http.StatusInternalServerError, err)
 		return
 	}
 
 	resp, err := exchangeAuthenticationCode(client, code)
 	if err != nil {
-		r.log.Error("unable to exchange code for access token", zap.Error(err))
-		r.accessForbidden(w, req)
+		r.accessForbidden(w, req, "unable to exchange code for access token", err.Error())
 		return
 	}
 
@@ -136,8 +133,7 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 	// to the ID Token.
 	token, identity, err := parseToken(resp.IDToken)
 	if err != nil {
-		r.log.Error("unable to parse id token for identity", zap.Error(err))
-		r.accessForbidden(w, req)
+		r.accessForbidden(w, req, "unable to parse ID token for identity", err.Error())
 		return
 	}
 	access, id, err := parseToken(resp.AccessToken)
@@ -150,8 +146,7 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 
 	// step: check the access token is valid
 	if err = verifyToken(r.client, token); err != nil {
-		r.log.Error("unable to verify the id token", zap.Error(err))
-		r.accessForbidden(w, req)
+		r.accessForbidden(w, req, "unable to verify the ID token", err.Error())
 		return
 	}
 	accessToken := token.Encode()
@@ -159,8 +154,7 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 	// step: are we encrypting the access token?
 	if r.config.EnableEncryptedToken || r.config.ForceEncryptedCookie {
 		if accessToken, err = encodeText(accessToken, r.config.EncryptionKey); err != nil {
-			r.log.Error("unable to encode the access token", zap.Error(err))
-			w.WriteHeader(http.StatusInternalServerError)
+			r.errorResponse(w, "unable to encode the access token", http.StatusInternalServerError, err)
 			return
 		}
 	}
@@ -178,8 +172,7 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 		var encrypted string
 		encrypted, err = encodeText(resp.RefreshToken, r.config.EncryptionKey)
 		if err != nil {
-			r.log.Error("failed to encrypt the refresh token", zap.Error(err))
-			w.WriteHeader(http.StatusInternalServerError)
+			r.errorResponse(w, "failed to encrypt the refresh token", http.StatusInternalServerError, err)
 			return
 		}
 		// drop in the access token - cookie expiration = access token
@@ -274,7 +267,7 @@ func (r *oauthProxy) loginHandler(w http.ResponseWriter, req *http.Request) {
 		// @metric a token has been issued
 		oauthTokensMetric.WithLabelValues("login").Inc()
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", jsonMime)
 		if err := json.NewEncoder(w).Encode(tokenResponse{
 			IDToken:      token.IDToken,
 			AccessToken:  token.AccessToken,
@@ -288,11 +281,7 @@ func (r *oauthProxy) loginHandler(w http.ResponseWriter, req *http.Request) {
 		return "", http.StatusOK, nil
 	}()
 	if err != nil {
-		r.log.Error(errorMsg,
-			zap.String("client_ip", req.RemoteAddr),
-			zap.Error(err))
-
-		w.WriteHeader(code)
+		r.errorResponse(w, strings.Join([]string{errorMsg, "client_ip", req.RemoteAddr}, ","), code, err)
 	}
 }
 
@@ -319,7 +308,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	// @step: drop the access token
 	user, err := r.getIdentity(req)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		r.errorResponse(w, "", http.StatusBadRequest, nil)
 		return
 	}
 
@@ -372,8 +361,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	if revocationURL != "" {
 		client, err := r.client.OAuthClient()
 		if err != nil {
-			r.log.Error("unable to retrieve the openid client", zap.Error(err))
-			w.WriteHeader(http.StatusInternalServerError)
+			r.errorResponse(w, "unable to retrieve the openid client", http.StatusInternalServerError, err)
 			return
 		}
 
@@ -384,8 +372,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 		// step: construct the url for revocation
 		request, err := http.NewRequest(http.MethodPost, revocationURL, bytes.NewBufferString(fmt.Sprintf("refresh_token=%s", identityToken)))
 		if err != nil {
-			r.log.Error("unable to construct the revocation request", zap.Error(err))
-			w.WriteHeader(http.StatusInternalServerError)
+			r.errorResponse(w, "unable to construct the revocation request", http.StatusInternalServerError, err)
 			return
 		}
 
@@ -415,21 +402,20 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	// step: should we redirect the user
 	if redirectURL != "" {
 		r.redirectToURL(redirectURL, w, req, http.StatusTemporaryRedirect)
+	} else {
+		w.Header().Set("Content-Type", jsonMime)
+		w.WriteHeader(http.StatusOK)
 	}
 }
 
 // expirationHandler checks if the token has expired
 func (r *oauthProxy) expirationHandler(w http.ResponseWriter, req *http.Request) {
 	user, err := r.getIdentity(req)
-	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+	if err != nil || user.isExpired() {
+		r.errorResponse(w, "", http.StatusUnauthorized, nil)
 		return
 	}
-
-	if user.isExpired() {
-		w.WriteHeader(http.StatusUnauthorized)
-		return
-	}
+	w.Header().Set("Content-Type", jsonMime)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -437,15 +423,16 @@ func (r *oauthProxy) expirationHandler(w http.ResponseWriter, req *http.Request)
 func (r *oauthProxy) tokenHandler(w http.ResponseWriter, req *http.Request) {
 	user, err := r.getIdentity(req)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		r.errorResponse(w, "", http.StatusBadRequest, nil)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", jsonMime)
 	_, _ = w.Write(user.token.Payload)
 }
 
 // healthHandler is a health check handler for the service
 func (r *oauthProxy) healthHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", jsonMime)
 	w.Header().Set(versionHeader, getVersion())
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("OK\n"))
@@ -475,14 +462,14 @@ func (r *oauthProxy) debugHandler(w http.ResponseWriter, req *http.Request) {
 		case symbolProfile:
 			pprof.Symbol(w, req)
 		default:
-			w.WriteHeader(http.StatusNotFound)
+			r.errorResponse(w, "", http.StatusNotFound, nil)
 		}
 	case http.MethodPost:
 		switch name {
 		case symbolProfile:
 			pprof.Symbol(w, req)
 		default:
-			w.WriteHeader(http.StatusNotFound)
+			r.errorResponse(w, "", http.StatusNotFound, nil)
 		}
 	}
 }
@@ -516,13 +503,5 @@ func (r *oauthProxy) retrieveRefreshToken(req *http.Request, user *userContext) 
 }
 
 func (r *oauthProxy) csrfErrorHandler(w http.ResponseWriter, req *http.Request) {
-	r.log.Info("CSRF error",
-		zap.Error(gcsrf.FailureReason(req)),
-		zap.String("client_ip", req.RemoteAddr))
-	r.accessForbidden(w, req)
-}
-
-func methodNotAllowHandlder(w http.ResponseWriter, req *http.Request) {
-	w.WriteHeader(http.StatusMethodNotAllowed)
-	_, _ = w.Write(nil)
+	r.accessForbidden(w, req, "CSRF error", gcsrf.FailureReason(req).Error(), req.RemoteAddr)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -428,6 +428,7 @@ func (r *oauthProxy) tokenHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	w.Header().Set("Content-Type", jsonMime)
 	_, _ = w.Write(user.token.Payload)
+	w.WriteHeader(http.StatusOK)
 }
 
 // healthHandler is a health check handler for the service
@@ -435,7 +436,7 @@ func (r *oauthProxy) healthHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", jsonMime)
 	w.Header().Set(versionHeader, getVersion())
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("OK\n"))
+	_, _ = w.Write([]byte(`{"status":"OK"}`))
 }
 
 // debugHandler is responsible for providing the pprof

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -336,7 +336,7 @@ func TestHealthHandler(t *testing.T) {
 		{
 			URI:             c.WithOAuthURI(healthURL),
 			ExpectedCode:    http.StatusOK,
-			ExpectedContent: "OK\n",
+			ExpectedContent: `{"status":"OK"}`,
 			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -49,16 +49,18 @@ func TestExpirationHandler(t *testing.T) {
 			ExpectedCode: http.StatusUnauthorized,
 		},
 		{
-			URI:          uri,
-			HasToken:     true,
-			Expires:      -48 * time.Hour,
-			ExpectedCode: http.StatusUnauthorized,
+			URI:             uri,
+			HasToken:        true,
+			Expires:         -48 * time.Hour,
+			ExpectedCode:    http.StatusUnauthorized,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
-			URI:          uri,
-			HasToken:     true,
-			Expires:      14 * time.Hour,
-			ExpectedCode: http.StatusOK,
+			URI:             uri,
+			HasToken:        true,
+			Expires:         14 * time.Hour,
+			ExpectedCode:    http.StatusOK,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 	}
 	newFakeProxy(nil).RunTests(t, requests)
@@ -139,8 +141,9 @@ func TestLoginHandler(t *testing.T) {
 func TestLogoutHandlerBadRequest(t *testing.T) {
 	requests := []fakeRequest{
 		{
-			URI:          newFakeKeycloakConfig().WithOAuthURI(logoutURL),
-			ExpectedCode: http.StatusUnauthorized,
+			URI:             newFakeKeycloakConfig().WithOAuthURI(logoutURL),
+			ExpectedCode:    http.StatusUnauthorized,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 	}
 	newFakeProxy(nil).RunTests(t, requests)
@@ -150,19 +153,22 @@ func TestLogoutHandlerBadToken(t *testing.T) {
 	c := newFakeKeycloakConfig()
 	requests := []fakeRequest{
 		{
-			URI:          c.WithOAuthURI(logoutURL),
-			ExpectedCode: http.StatusUnauthorized,
+			URI:             c.WithOAuthURI(logoutURL),
+			ExpectedCode:    http.StatusUnauthorized,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
-			URI:            c.WithOAuthURI(logoutURL),
-			HasCookieToken: true,
-			RawToken:       "this.is.a.bad.token",
-			ExpectedCode:   http.StatusUnauthorized,
+			URI:             c.WithOAuthURI(logoutURL),
+			HasCookieToken:  true,
+			RawToken:        "this.is.a.bad.token",
+			ExpectedCode:    http.StatusUnauthorized,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
-			URI:          c.WithOAuthURI(logoutURL),
-			RawToken:     "this.is.a.bad.token",
-			ExpectedCode: http.StatusUnauthorized,
+			URI:             c.WithOAuthURI(logoutURL),
+			RawToken:        "this.is.a.bad.token",
+			ExpectedCode:    http.StatusUnauthorized,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 	}
 	newFakeProxy(nil).RunTests(t, requests)
@@ -172,9 +178,10 @@ func TestLogoutHandlerGood(t *testing.T) {
 	c := newFakeKeycloakConfig()
 	requests := []fakeRequest{
 		{
-			URI:          c.WithOAuthURI(logoutURL),
-			HasToken:     true,
-			ExpectedCode: http.StatusOK,
+			URI:             c.WithOAuthURI(logoutURL),
+			HasToken:        true,
+			ExpectedCode:    http.StatusOK,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
 			URI:              c.WithOAuthURI(logoutURL) + "?redirect=http://example.com",
@@ -191,25 +198,29 @@ func TestTokenHandler(t *testing.T) {
 	goodToken := newTestToken("example").getToken()
 	requests := []fakeRequest{
 		{
-			URI:          uri,
-			HasToken:     true,
-			RawToken:     (&goodToken).Encode(),
-			ExpectedCode: http.StatusOK,
+			URI:             uri,
+			HasToken:        true,
+			RawToken:        (&goodToken).Encode(),
+			ExpectedCode:    http.StatusOK,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
-			URI:          uri,
-			ExpectedCode: http.StatusUnauthorized,
+			URI:             uri,
+			ExpectedCode:    http.StatusUnauthorized,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
-			URI:          uri,
-			RawToken:     "niothing",
-			ExpectedCode: http.StatusUnauthorized,
+			URI:             uri,
+			RawToken:        "niothing",
+			ExpectedCode:    http.StatusUnauthorized,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
-			URI:            uri,
-			HasToken:       true,
-			HasCookieToken: true,
-			ExpectedCode:   http.StatusOK,
+			URI:             uri,
+			HasToken:        true,
+			HasCookieToken:  true,
+			ExpectedCode:    http.StatusOK,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 	}
 	newFakeProxy(nil).RunTests(t, requests)
@@ -236,8 +247,9 @@ func TestAuthorizationURLWithSkipToken(t *testing.T) {
 	c.SkipTokenVerification = true
 	newFakeProxy(c).RunTests(t, []fakeRequest{
 		{
-			URI:          c.WithOAuthURI(authorizationURL),
-			ExpectedCode: http.StatusNotAcceptable,
+			URI:             c.WithOAuthURI(authorizationURL),
+			ExpectedCode:    http.StatusNotAcceptable,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 	})
 }
@@ -286,13 +298,15 @@ func TestCallbackURL(t *testing.T) {
 	cfg := newFakeKeycloakConfig()
 	requests := []fakeRequest{
 		{
-			URI:          cfg.WithOAuthURI(callbackURL),
-			Method:       http.MethodPost,
-			ExpectedCode: http.StatusMethodNotAllowed,
+			URI:             cfg.WithOAuthURI(callbackURL),
+			Method:          http.MethodPost,
+			ExpectedCode:    http.StatusMethodNotAllowed,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
-			URI:          cfg.WithOAuthURI(callbackURL),
-			ExpectedCode: http.StatusBadRequest,
+			URI:             cfg.WithOAuthURI(callbackURL),
+			ExpectedCode:    http.StatusBadRequest,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
 			URI:              cfg.WithOAuthURI(callbackURL) + "?code=fake",
@@ -323,11 +337,13 @@ func TestHealthHandler(t *testing.T) {
 			URI:             c.WithOAuthURI(healthURL),
 			ExpectedCode:    http.StatusOK,
 			ExpectedContent: "OK\n",
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 		{
-			URI:          c.WithOAuthURI(healthURL),
-			Method:       http.MethodHead,
-			ExpectedCode: http.StatusMethodNotAllowed,
+			URI:             c.WithOAuthURI(healthURL),
+			Method:          http.MethodHead,
+			ExpectedCode:    http.StatusMethodNotAllowed,
+			ExpectedHeaders: map[string]string{"Content-Type": jsonMime},
 		},
 	}
 	newFakeProxy(nil).RunTests(t, requests)

--- a/noforwarding.go
+++ b/noforwarding.go
@@ -1,0 +1,20 @@
+//+build noforwarding
+
+package main
+
+import (
+	"errors"
+	"net/http"
+)
+
+func (r *Config) isForwardingValid() error {
+	return errors.New("forwarding mode is not enabled in this build: you can't enable EnableForwarding")
+}
+
+func (r *oauthProxy) createForwardingProxy() error {
+	return nil
+}
+
+func (r *oauthProxy) forwardProxyHandler() func(*http.Request, *http.Response) {
+	return func(_ *http.Request, _ *http.Response) {}
+}

--- a/nostores.go
+++ b/nostores.go
@@ -1,0 +1,40 @@
+//+build nostores
+
+package main
+
+import (
+	"errors"
+
+	"github.com/coreos/go-oidc/jose"
+)
+
+func (r *Config) isStoreValid() error {
+	if r.StoreURL != "" {
+		return errors.New("remote stores are disabled in this build: you can't configure StoreURL")
+	}
+	return nil
+}
+
+func createStorage(location string) (storage, error) {
+	return nil, nil
+}
+
+func (r *oauthProxy) useStore() bool {
+	return false
+}
+
+func (r *oauthProxy) StoreRefreshToken(token jose.JWT, value string) error {
+	return nil
+}
+
+func (r *oauthProxy) CloseStore() error {
+	return nil
+}
+
+func (r *oauthProxy) GetRefreshToken(token jose.JWT) (string, error) {
+	return "", nil
+}
+
+func (r *oauthProxy) DeleteRefreshToken(token jose.JWT) error {
+	return nil
+}

--- a/store_boltdb.go
+++ b/store_boltdb.go
@@ -1,3 +1,5 @@
+//+build !nostores
+
 /*
 Copyright 2015 All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/store_redis.go
+++ b/store_redis.go
@@ -1,3 +1,5 @@
+//+build !nostores
+
 /*
 Copyright 2015 All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/stores.go
+++ b/stores.go
@@ -1,3 +1,5 @@
+//+build !nostores
+
 /*
 Copyright 2015 All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +25,15 @@ import (
 	"go.uber.org/zap"
 )
 
+func (r *Config) isStoreValid() error {
+	if r.StoreURL != "" {
+		if _, err := url.Parse(r.StoreURL); err != nil {
+			return fmt.Errorf("the store url is invalid, error: %s", err)
+		}
+	}
+	return nil
+}
+
 // createStorage creates the store client for use
 func createStorage(location string) (storage, error) {
 	var store storage
@@ -38,7 +49,7 @@ func createStorage(location string) (storage, error) {
 	case "boltdb":
 		store, err = newBoltDBStore(u)
 	default:
-		return nil, fmt.Errorf("unsupport store: %s", u.Scheme)
+		return nil, fmt.Errorf("unsupported store: %s", u.Scheme)
 	}
 
 	return store, err


### PR DESCRIPTION
* Fixes #10 (build tags and reduce unused deps)
* Error responses enforce Content-Type: application/json; charset=utf-8
* Health responds as JSON
* Handlers with empty responses (e.g. logout, expired, ....) respond with Content-Type