### PR TITLE
fix: typo in cache-control header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,6 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
@@ -50,3 +48,5 @@ require (
 	gopkg.in/resty.v1 v1.12.0
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/misc.go
+++ b/misc.go
@@ -70,7 +70,7 @@ func (r *oauthProxy) revokeProxy(w http.ResponseWriter, req *http.Request) conte
 // redirectToURL redirects the user and aborts the context
 func (r *oauthProxy) redirectToURL(url string, w http.ResponseWriter, req *http.Request, statusCode int) context.Context {
 	r.log.Debug("redirecting to", zap.String("location", url))
-	w.Header().Add("Cache-Control", "nocache, no-store, must-revalidate, max-age=0")
+	w.Header().Add("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 	http.Redirect(w, req, url, statusCode)
 
 	return r.revokeProxy(w, req)


### PR DESCRIPTION
fix: typo in cache-control header

* go.mod update for go1.13
* fixed cache-control directive: nocache = no-cache

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>