### PR TITLE
Fix request uri cookie

### DIFF
--- a/config.go
+++ b/config.go
@@ -370,8 +370,8 @@ func (r *Config) isReverseProxyValid() error {
 		}
 	}
 
-	if r.SkipUpstreamTLSVerify && r.UpstreamCA != "" {
-		return fmt.Errorf("you cannot both require to skip upstream tls and load a root ca to verify it: %s", r.UpstreamCA)
+	if !r.SkipUpstreamTLSVerify && r.UpstreamCA == "" {
+		return fmt.Errorf("you cannot require to check upstream tls and omit to specify the root ca to verify it: %s", r.UpstreamCA)
 	}
 
 	// step: if token verification is enabled (skip is off), we need the below checks

--- a/config_test.go
+++ b/config_test.go
@@ -30,13 +30,16 @@ func TestNewDefaultConfig(t *testing.T) {
 
 func TestIsConfig(t *testing.T) {
 	tests := []struct {
+		Name   string
 		Config *Config
 		Ok     bool
 	}{
 		{
+			Name:   "empty config",
 			Config: &Config{},
 		},
 		{
+			Name: "wrong discovery URL",
 			Config: &Config{
 				DiscoveryURL: "http://127.0.0.1:8080",
 			},
@@ -69,27 +72,31 @@ func TestIsConfig(t *testing.T) {
 		},
 		{
 			Config: &Config{
-				Listen:              ":8080",
-				DiscoveryURL:        "http://127.0.0.1:8080",
-				ClientID:            "client",
-				ClientSecret:        "client",
-				RedirectionURL:      "http://120.0.0.1",
-				Upstream:            "http://120.0.0.1",
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 50,
+				Listen:                ":8080",
+				DiscoveryURL:          "http://127.0.0.1:8080",
+				ClientID:              "client",
+				ClientSecret:          "client",
+				RedirectionURL:        "http://120.0.0.1",
+				SkipUpstreamTLSVerify: false,
+				Upstream:              "http://120.0.0.1",
+				UpstreamCA:            "someCA",
+				MaxIdleConns:          100,
+				MaxIdleConnsPerHost:   50,
 			},
 			Ok: true,
 		},
 		{
 			Config: &Config{
-				Listen:              ":8080",
-				DiscoveryURL:        "http://127.0.0.1:8080",
-				ClientID:            "client",
-				ClientSecret:        "client",
-				RedirectionURL:      "http://120.0.0.1",
-				Upstream:            "http://120.0.0.1",
-				MaxIdleConns:        0,
-				MaxIdleConnsPerHost: 0,
+				Listen:                ":8080",
+				DiscoveryURL:          "http://127.0.0.1:8080",
+				ClientID:              "client",
+				ClientSecret:          "client",
+				RedirectionURL:        "http://120.0.0.1",
+				SkipUpstreamTLSVerify: false,
+				Upstream:              "http://120.0.0.1",
+				UpstreamCA:            "someCA",
+				MaxIdleConns:          0,
+				MaxIdleConnsPerHost:   0,
 			},
 		},
 		{
@@ -120,27 +127,32 @@ func TestIsConfig(t *testing.T) {
 			},
 		},
 		{
+			Name: "happy path",
 			Config: &Config{
 				Listen:                ":8080",
 				SkipTokenVerification: true,
 				Upstream:              "http://120.0.0.1",
+				UpstreamCA:            "someCA",
 				MaxIdleConns:          100,
 				MaxIdleConnsPerHost:   50,
 			},
 			Ok: true,
 		},
 		{
+			Name: "invalid",
 			Config: &Config{
-				DiscoveryURL:        "http://127.0.0.1:8080",
-				ClientID:            "client",
-				ClientSecret:        "client",
-				RedirectionURL:      "http://120.0.0.1",
-				Upstream:            "http://120.0.0.1",
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 50,
+				DiscoveryURL:          "http://127.0.0.1:8080",
+				ClientID:              "client",
+				ClientSecret:          "client",
+				RedirectionURL:        "http://120.0.0.1",
+				SkipUpstreamTLSVerify: true,
+				Upstream:              "http://120.0.0.1",
+				MaxIdleConns:          100,
+				MaxIdleConnsPerHost:   50,
 			},
 		},
 		{
+			Name: "invalid (2)",
 			Config: &Config{
 				Listen:              ":8080",
 				DiscoveryURL:        "http://127.0.0.1:8080",
@@ -152,49 +164,58 @@ func TestIsConfig(t *testing.T) {
 			},
 		},
 		{
+			Name: "invalid (3)",
 			Config: &Config{
-				Listen:              ":8080",
-				DiscoveryURL:        "http://127.0.0.1:8080",
-				ClientID:            "client",
-				ClientSecret:        "client",
-				RedirectionURL:      "http://120.0.0.1",
-				Upstream:            "this should fail",
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 50,
+				Listen:                ":8080",
+				DiscoveryURL:          "http://127.0.0.1:8080",
+				ClientID:              "client",
+				ClientSecret:          "client",
+				RedirectionURL:        "http://120.0.0.1",
+				SkipUpstreamTLSVerify: false,
+				Upstream:              "this should fail",
+				MaxIdleConns:          100,
+				MaxIdleConnsPerHost:   50,
 			},
 		},
 		{
+			Name: "invalid upstream",
 			Config: &Config{
-				Listen:              ":8080",
-				DiscoveryURL:        "http://127.0.0.1:8080",
-				ClientID:            "client",
-				ClientSecret:        "client",
-				RedirectionURL:      "http://120.0.0.1",
-				Upstream:            "this should fail",
-				SecureCookie:        true,
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 50,
+				Listen:                ":8080",
+				DiscoveryURL:          "http://127.0.0.1:8080",
+				ClientID:              "client",
+				ClientSecret:          "client",
+				RedirectionURL:        "http://120.0.0.1",
+				SkipUpstreamTLSVerify: true,
+				Upstream:              "this should fail",
+				SecureCookie:          true,
+				MaxIdleConns:          100,
+				MaxIdleConnsPerHost:   50,
 			},
 		},
 		{
+			Name: "happy path",
 			Config: &Config{
-				Listen:              ":8080",
-				DiscoveryURL:        "http://127.0.0.1:8080",
-				ClientID:            "client",
-				ClientSecret:        "client",
-				RedirectionURL:      "https://120.0.0.1",
-				Upstream:            "this should fail",
-				SecureCookie:        true,
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 50,
+				Listen:                ":8080",
+				DiscoveryURL:          "http://127.0.0.1:8080",
+				ClientID:              "client",
+				ClientSecret:          "client",
+				RedirectionURL:        "https://120.0.0.1",
+				SkipUpstreamTLSVerify: true,
+				Upstream:              "this should not fail",
+				SecureCookie:          true,
+				MaxIdleConns:          100,
+				MaxIdleConnsPerHost:   50,
 			},
 			Ok: true,
 		},
 	}
 
 	for i, c := range tests {
-		if err := c.Config.isValid(); err != nil && c.Ok {
-			t.Errorf("test case %d, the config should not have errored, error: %s", i, err)
+		err := c.Config.isValid()
+		if c.Ok {
+			assert.NoErrorf(t, err, "test case %d (%q), the config should not have errored, error: %v", i, c.Name, err)
+		} else {
+			assert.Errorf(t, err, "test case %d (%q), the config should have errored", i, c.Name)
 		}
 	}
 }

--- a/cookies.go
+++ b/cookies.go
@@ -16,7 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"encoding/base64"
 	"net/http"
 	"strconv"
 	"strings"
@@ -98,8 +97,6 @@ func (r *oauthProxy) dropRefreshTokenCookie(req *http.Request, w http.ResponseWr
 // writeStateParameterCookie sets a state parameter cookie into the response
 func (r *oauthProxy) writeStateParameterCookie(req *http.Request, w http.ResponseWriter) string {
 	uuid := uuid.NewV4().String()
-	requestURI := base64.StdEncoding.EncodeToString([]byte(req.URL.RequestURI()))
-	r.dropCookie(w, req.Host, requestURICookie, requestURI, 0)
 	r.dropCookie(w, req.Host, requestStateCookie, uuid, 0)
 	return uuid
 }

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -184,6 +184,10 @@ func (r *oauthProxy) createReverseProxy() error {
 		r.log.Info("session access tokens will be encrypted")
 	}
 
+	if r.config.SkipUpstreamTLSVerify && r.config.UpstreamCA != "" {
+		r.log.Warn("you have specified an upstream CA to check, but have left the skip-upstream-tls-verify parameter to true (the default)")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
* fix: request_uri cookie should remain a client-side cookie only
* fix: config check should only warn about upstream CA config mismatch

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>