### PR TITLE
[KEYCLOAK-9880] Make sure the Authorization Header token is only cons…

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -50,4 +50,5 @@ const (
 	headerXFrameOptions       = "X-Frame-Options"
 	headerXSTS                = "X-Strict-Transport-Security"
 	headerXPolicy             = "X-Content-Security-Policy"
+	authorizationType         = "Bearer"
 )

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -315,7 +315,7 @@ func postUpstreamWithAccessTokenTest(t *testing.T, config *Config, cookies []*ht
 	u, _ := url.Parse("http://" + e2eCsrfProxyListener + e2eCsrfUpstreamURL)
 	h := make(http.Header, 10)
 	h.Set("Content-Type", "application/json")
-	h.Add("Authorization", "Bearer: "+accessToken)
+	h.Add("Authorization", "Bearer "+accessToken)
 	req := &http.Request{
 		Method: "POST",
 		URL:    u,
@@ -379,7 +379,6 @@ func postUpstream2Test(t *testing.T, config *Config, cookies []*http.Cookie) (st
 }
 
 func TestCSRF(t *testing.T) {
-	//log.SetOutput(ioutil.Discard)
 	config := newDefaultConfig()
 	config.Verbose = false
 	config.DisableAllLogging = true

--- a/session.go
+++ b/session.go
@@ -98,6 +98,9 @@ func getTokenInBearer(req *http.Request) (string, error) {
 		return "", ErrInvalidSession
 	}
 
+	if items[0] != authorizationType { // only accept bearer authorization type
+		return "", ErrSessionNotFound
+	}
 	return items[1], nil
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -42,6 +42,20 @@ func TestGetIndentity(t *testing.T) {
 		},
 		{
 			Request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"Basic QWxhZGRpbjpPcGVuU2VzYW1l"},
+				},
+			},
+		},
+		{
+			Request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{fmt.Sprintf("Test %s", encoded)},
+				},
+			},
+		},
+		{
+			Request: &http.Request{
 				Header: http.Header{},
 			},
 		},
@@ -66,31 +80,42 @@ func TestGetTokenInRequest(t *testing.T) {
 	defaultName := newDefaultConfig().CookieAccessName
 	token := newTestToken("test").getToken()
 	cs := []struct {
-		Token    string
-		IsBearer bool
-		Error    error
+		Token      string
+		AuthScheme string
+		Error      error
 	}{
 		{
-			Token: "",
-			Error: ErrSessionNotFound,
+			Token:      "",
+			AuthScheme: "",
+			Error:      ErrSessionNotFound,
 		},
 		{
-			Token: token.Encode(),
-			Error: nil,
+			Token:      token.Encode(),
+			AuthScheme: "",
+			Error:      nil,
 		},
 		{
-			Token:    token.Encode(),
-			IsBearer: true,
-			Error:    nil,
+			Token:      token.Encode(),
+			AuthScheme: "Bearer",
+			Error:      nil,
+		},
+		{
+			Token:      "QWxhZGRpbjpPcGVuU2VzYW1l",
+			AuthScheme: "Basic",
+			Error:      ErrSessionNotFound,
+		},
+		{
+			Token:      token.Encode(),
+			AuthScheme: "Test",
+			Error:      ErrSessionNotFound,
 		},
 	}
 	for i, x := range cs {
 		req := newFakeHTTPRequest(http.MethodGet, "/")
 		if x.Token != "" {
-			switch x.IsBearer {
-			case true:
-				req.Header.Set(authorizationHeader, "Bearer "+x.Token)
-			default:
+			if x.AuthScheme != "" {
+				req.Header.Set(authorizationHeader, x.AuthScheme+" "+x.Token)
+			} else {
 				req.AddCookie(&http.Cookie{
 					Name:   defaultName,
 					Path:   req.URL.Path,
@@ -103,7 +128,7 @@ func TestGetTokenInRequest(t *testing.T) {
 		switch x.Error {
 		case nil:
 			assert.NoError(t, err, "case %d should not have thrown an error", i)
-			assert.Equal(t, x.IsBearer, bearer)
+			assert.Equal(t, x.AuthScheme == "Bearer", bearer)
 			assert.Equal(t, token.Encode(), access)
 		default:
 			assert.Equal(t, x.Error, err, "case %d, expected error: %s", i, x.Error)


### PR DESCRIPTION
…idered when type is Bearer (#471)

* Make sure Authorization Header token is only considered when type is Bearer
* Adjusted Session test cases to verify that the Basic Authentication Schema is ignored
* Added new testcases for Authentication Sceme handling