### PR TITLE
feat(ops): [RES-2181] Cleaned up circleci details

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           password: $GCLOUD_SERVICE_KEY
     environment:
       REPOSITORY: 'gcr.io/onec-co'
-      GOOGLE_PROJECT_ID: "onec-co"
+      GOOGLE_PROJECT_ID: ${GOOGLE_PROJECT_ID}
       GOOGLE_COMPUTE_ZONE: us-west2-c
       IMAGE: gatekeeper
     shell: /bin/bash
@@ -31,7 +31,7 @@ jobs:
             gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
             gcloud --quiet config set container/new_scopes_behavior true
-            gcloud --quiet container clusters get-credentials onec-dev
+            gcloud --quiet container clusters get-credentials ${CLUSTER}
       - checkout
       - setup_remote_docker:
           version: 18.09.3


### PR DESCRIPTION
Description:
Keycloak Gatekeeper being an Open Source Project we don’t want any One Concern details revealed to the public anywhere in the code base. And we noticed that on the Circle CI yaml file there are a couple of parameters that are revealed and should not be.

Got rid of:

Google Project ID
Cluster Name