### PR TITLE
Tracing & perf update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,23 @@
 version: 2.0
 jobs:
+  lint:
+    docker:
+      - image: golangci/golangci-lint:latest-alpine
+    environment:
+      GO111MODULE: "on"
+    working_directory: ~/project
+    steps:
+      - run:
+          name: Install prerequisites for alpine
+          command: |
+            apk add git openssh-client ncurses
+      - checkout
+      - run:
+          name: Run linter
+          environment:
+          command: |
+            golangci-lint run --deadline 2m --new-from-rev master
+
   test:
     working_directory: /go/src/github.com/oneconcern/keycloak-gatekeeper
     docker:
@@ -60,6 +78,14 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - lint:
+          context: "OC Common"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+
       - test:
           context: "OC Common"
           filters:
@@ -67,9 +93,11 @@ workflows:
               only: /.*/
             branches:
               only: /.*/
+
       - build_image:
           context: "OC Common"
           requires:
+            - lint
             - test
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,8 @@ workflows:
 
       - test:
           context: "OC Common"
+          requires:
+            - lint
           filters:
             tags:
               only: /.*/
@@ -97,7 +99,6 @@ workflows:
       - build_image:
           context: "OC Common"
           requires:
-            - lint
             - test
           filters:
             tags:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,3 +35,5 @@ linters:
     - gofumpt
     - godot
     - gci
+    - exhaustivestruct
+    - wrapcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,3 +37,4 @@ linters:
     - gci
     - exhaustivestruct
     - wrapcheck
+    - errorlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,3 +27,11 @@ linters:
     - funlen
     - godox
     - gomnd
+    - nlreturn
+    - testpackage
+    - goerr113
+    - nestif
+    - exhaustive
+    - gofumpt
+    - godot
+    - gci

--- a/config_test.go
+++ b/config_test.go
@@ -192,7 +192,7 @@ func TestIsConfigValid(t *testing.T) {
 				EnableCSRF:            true,
 				EncryptionKey:         "xx",
 				Resources: []*Resource{
-					&Resource{
+					{
 						URL: "http://localhost/there",
 					},
 				},
@@ -213,7 +213,7 @@ func TestIsConfigValid(t *testing.T) {
 				EnableCSRF:            true,
 				EncryptionKey:         "xx",
 				Resources: []*Resource{
-					&Resource{
+					{
 						URL: "http://localhost/there",
 					},
 				},
@@ -267,7 +267,7 @@ func TestIsConfigValid(t *testing.T) {
 				MaxIdleConns:          100,
 				MaxIdleConnsPerHost:   50,
 				Resources: []*Resource{
-					&Resource{
+					{
 						URL:  "/nowhere",
 						URLs: []string{"/somewhere"},
 					},
@@ -289,10 +289,10 @@ func TestIsConfigValid(t *testing.T) {
 				MaxIdleConns:          100,
 				MaxIdleConnsPerHost:   50,
 				Resources: []*Resource{
-					&Resource{
+					{
 						URLs: []string{"/somewhere", "/everywhere"},
 					},
-					&Resource{
+					{
 						URL: "/somewhere",
 					},
 				},
@@ -357,7 +357,7 @@ func TestIsConfigValid(t *testing.T) {
 				MaxIdleConns:          100,
 				MaxIdleConnsPerHost:   50,
 				Resources: []*Resource{
-					&Resource{
+					{
 						URLs: []string{"/somewhere", "/everywhere"},
 					},
 				},

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -64,6 +64,7 @@ func checkListenOrBail(endpoint string) bool {
 	)
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
 			RootCAs:    makeTestCACertPool(),
 			NextProtos: []string{"h2", "http/1.1"},
 		},
@@ -75,6 +76,7 @@ func checkListenOrBail(endpoint string) bool {
 	checkListen := http.Client{
 		Transport: transport,
 	}
+	// nolint: noctx
 	resp, err := checkListen.Get(endpoint)
 	if err == nil {
 		defer func() {
@@ -84,6 +86,7 @@ func checkListenOrBail(endpoint string) bool {
 	limit := 0
 	for err != nil && limit < maxWaitCycles {
 		time.Sleep(waitTime)
+		// nolint: noctx
 		resp, err = checkListen.Get(endpoint)
 		if err == nil {
 			defer func() {

--- a/e2e_tls_test.go
+++ b/e2e_tls_test.go
@@ -130,7 +130,6 @@ func runTestTLSUpstream(t *testing.T, listener, route string, markers ...string)
 	return nil
 }
 
-// TODO(fred)nolint: dupl
 func runTestTLSApp(t *testing.T, listener, route string) error {
 	go func() {
 		mux := http.NewServeMux()

--- a/e2e_tls_test.go
+++ b/e2e_tls_test.go
@@ -65,8 +65,8 @@ func runTestTLSUpstream(t *testing.T, listener, route string, markers ...string)
 	go func() {
 		upstreamHandler := func(w http.ResponseWriter, req *http.Request) {
 			// NOTE: to debug, enable request dump
-			//dump, _ := httputil.DumpRequest(req, false)
-			//t.Logf("upstream received: %q", string(dump))
+			// dump, _ := httputil.DumpRequest(req, false)
+			// t.Logf("upstream received: %q", string(dump))
 			nowPushing := false
 			inBody := make([]string, 0, len(markers))
 			inPushed := make([]string, 0, len(markers))
@@ -130,7 +130,7 @@ func runTestTLSUpstream(t *testing.T, listener, route string, markers ...string)
 	return nil
 }
 
-// nolint: dupl
+// TODO(fred)nolint: dupl
 func runTestTLSApp(t *testing.T, listener, route string) error {
 	go func() {
 		mux := http.NewServeMux()
@@ -306,7 +306,7 @@ func testBuildTLSUpstreamConfig() *Config {
 	config.Listen = e2eTLSUpstreamProxyListener
 	config.ListenHTTP = ""
 	config.DiscoveryURL = testTLSDiscoveryURL(e2eTLSUpstreamOauthListener, "hod-test")
-	//config.SkipOpenIDProviderTLSVerify = true
+	// config.SkipOpenIDProviderTLSVerify = true
 	config.OpenIDProviderCA = caCert
 
 	config.Upstream = "https://" + e2eTLSUpstreamUpstreamListener
@@ -348,7 +348,7 @@ func testBuildTLSUpstreamConfig() *Config {
 }
 
 func TestTLSUpstream(t *testing.T) {
-	//log.SetOutput(ioutil.Discard)
+	// log.SetOutput(ioutil.Discard)
 
 	config := testBuildTLSUpstreamConfig()
 	require.NoError(t, config.isValid())
@@ -416,9 +416,9 @@ func TestTLSUpstream(t *testing.T) {
 	}()
 
 	// NOTE: to debug, enable response dump
-	//dump, err := httputil.DumpResponse(resp, true)
-	//require.NoError(t, err)
-	//t.Logf("%q", dump)
+	// dump, err := httputil.DumpResponse(resp, true)
+	// require.NoError(t, err)
+	// t.Logf("%q", dump)
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	// also interactive test may produce HTTP/2 traces:
@@ -429,7 +429,7 @@ func TestTLSUpstream(t *testing.T) {
 	assert.Contains(t, string(buf), "mark1")
 
 	// NOTE: to debug, enable response dump
-	//t.Logf(string(buf))
+	// t.Logf(string(buf))
 
 	// test token endpoint: this returns the json content of the access token
 	// e.g:  {"aud":"test","azp":"clientid","client_session":"f0105893-369a-46bc-9661-ad8c747b1a69","email":"gambol99@gmail.com","exp":1565256043,"family_name":"Jayawardene","given_name":"Rohith","iat":1565252443,"iss":"https://auth.localtest.me:13455/auth/realms/hod-test","jti":"4ee75b8e-3ee6-4382-92d4-3390b4b4937b","name":"Rohith Jayawardene","nbf":0,"preferred_username":"rjayawardene","session_state":"98f4c3d2-1b8c-4932-b8c4-92ec0ea7e195","sub":"1e11e539-8256-4b3b-bda8-cc0d56cddb48","typ":"Bearer"}
@@ -549,7 +549,7 @@ func TestTLSUpstream(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	buf, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	//t.Logf("rpcz: %s", string(buf))
+	// t.Logf("rpcz: %s", string(buf))
 	assert.Contains(t, string(buf), `<!DOCTYPE html>`)
 
 	u, _ = url.Parse("https://" + e2eTLSAdminEndpointListener + "/oauth/trace/tracez")
@@ -562,7 +562,7 @@ func TestTLSUpstream(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	buf, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	//t.Logf("tracez: %s", string(buf))
+	// t.Logf("tracez: %s", string(buf))
 	assert.Contains(t, string(buf), `<!DOCTYPE html>`)
 
 	u, _ = url.Parse("https://" + e2eTLSAdminEndpointListener + `/oauth/trace/tracez?zspanname=%2foauth%2frefresh&ztype=1&zsubtype=4`)
@@ -575,6 +575,6 @@ func TestTLSUpstream(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	buf, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	//t.Logf("tracez: %s", string(buf))
+	// t.Logf("tracez: %s", string(buf))
 	assert.Contains(t, string(buf), `<!DOCTYPE html>`)
 }

--- a/e2e_ws_test.go
+++ b/e2e_ws_test.go
@@ -50,8 +50,8 @@ func runTestWSTLSUpstream(t *testing.T, listener, route string) error {
 	const health = "health"
 	go func() {
 		upstreamHandler := func(w http.ResponseWriter, req *http.Request) {
-			//dump, _ := httputil.DumpRequest(req, false)
-			//t.Logf("upstream received: %q", string(dump))
+			// dump, _ := httputil.DumpRequest(req, false)
+			// t.Logf("upstream received: %q", string(dump))
 			c, err := upgrader.Upgrade(w, req, nil)
 			if err != nil {
 				t.Logf("server upgrade error: %v", err)
@@ -189,7 +189,7 @@ func testBuildWSTLSUpstreamConfig() *Config {
 	config.Listen = e2eWSTLSUpstreamProxyListener
 	config.ListenHTTP = ""
 	config.DiscoveryURL = testTLSDiscoveryURL(e2eWSTLSUpstreamOauthListener, "hod-test")
-	//config.SkipOpenIDProviderTLSVerify = true
+	// config.SkipOpenIDProviderTLSVerify = true
 	config.OpenIDProviderCA = caCert
 
 	config.Upstream = "https://" + e2eWSTLSUpstreamUpstreamListener
@@ -227,7 +227,7 @@ func testBuildWSTLSUpstreamConfig() *Config {
 }
 
 func TestWSTLSUpstream(t *testing.T) {
-	//log.SetOutput(ioutil.Discard)
+	// log.SetOutput(ioutil.Discard)
 
 	config := testBuildWSTLSUpstreamConfig()
 	require.NoError(t, config.isValid())

--- a/handlers.go
+++ b/handlers.go
@@ -403,7 +403,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 		encodedSecret := url.QueryEscape(r.config.ClientSecret)
 
 		// step: construct the url for revocation
-		request, err := http.NewRequest(http.MethodPost, revocationURL, bytes.NewBufferString(fmt.Sprintf("refresh_token=%s", identityToken)))
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, revocationURL, bytes.NewBufferString(fmt.Sprintf("refresh_token=%s", identityToken)))
 		if err != nil {
 			r.errorResponse(w, req.WithContext(ctx), "unable to construct the revocation request", http.StatusInternalServerError, err)
 			return

--- a/internal/log/spanlogger.go
+++ b/internal/log/spanlogger.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"math"
 	"time"
 
@@ -33,9 +34,15 @@ type Logger struct {
 
 // New Logger
 func New(logger *zap.Logger, span *trace.Span) *Logger {
+	stx := span.SpanContext()
+	traceID := binary.BigEndian.Uint64(stx.TraceID[8:])
+	spanID := binary.BigEndian.Uint64(stx.SpanID[:])
+
 	return &Logger{
-		logger: logger,
-		span:   span,
+		logger: logger.
+			WithOptions(zap.AddCallerSkip(1)).
+			With(zap.Uint64("dd.trace_id", traceID), zap.Uint64("dd.span_id", spanID)),
+		span: span,
 	}
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -547,7 +547,7 @@ func (r *oauthProxy) csrfHeaderMiddleware() func(next http.Handler) http.Handler
 					return
 				}
 
-				//skip requests with credentials in header
+				// skip requests with credentials in header
 				if scope.Identity.isBearer() {
 					next.ServeHTTP(w, req)
 					return

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -122,7 +122,7 @@ func (f *fakeProxy) RunTests(t *testing.T, requests []fakeRequest) {
 
 	for i := range requests {
 		c := requests[i]
-		//t.Logf("RunTests[%d]: %#v", i, c)
+		// t.Logf("RunTests[%d]: %#v", i, c)
 		var upstream fakeUpstreamResponse
 
 		f.config.NoRedirects = !c.Redirects

--- a/oauth.go
+++ b/oauth.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -101,9 +102,9 @@ func exchangeAuthenticationCode(client *oauth2.Client, code string) (oauth2.Toke
 	return getToken(client, oauth2.GrantTypeAuthCode, code)
 }
 
-// getUserinfo is responsible for getting the userinfo from the IDPD
+// getUserinfo is responsible for getting the userinfo from the IDP
 func getUserinfo(client *oauth2.Client, endpoint string, token string) (jose.Claims, error) {
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -335,6 +335,7 @@ func TestTokenExpired(t *testing.T) {
 func getRandomString(n int) string {
 	b := make([]rune, n)
 	for i := range b {
+		// #nosec
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)

--- a/resource.go
+++ b/resource.go
@@ -48,7 +48,7 @@ type Resource struct {
 	// Upstream is the upstream endpoint i.e whom were proxying to
 	Upstream string `json:"upstream-url" yaml:"upstream-url" usage:"url for the upstream endpoint you wish to proxy this resource"`
 	// TODO: UpstreamCA is the path to a CA certificate in PEM format to validate the upstream certificate
-	//UpstreamCA string `json:"upstream-ca" yaml:"upstream-ca" usage:"the path to a file container a CA certificate to validate the upstream tls endpoint for this resource"`
+	// UpstreamCA string `json:"upstream-ca" yaml:"upstream-ca" usage:"the path to a file container a CA certificate to validate the upstream tls endpoint for this resource"`
 }
 
 func newResource() *Resource {

--- a/server.go
+++ b/server.go
@@ -591,7 +591,10 @@ func (r *oauthProxy) Render(w io.Writer, name string, data interface{}) error {
 
 func (r *oauthProxy) buildProxyTLSConfig() (*tls.Config, error) {
 	//nolint:gas
-	tlsConfig := &tls.Config{InsecureSkipVerify: r.config.SkipUpstreamTLSVerify}
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: r.config.SkipUpstreamTLSVerify,
+		ClientSessionCache: tls.NewLRUClientSessionCache(0),
+	}
 
 	// are we using a client certificate?
 	// @TODO provide a means to reload the client certificate when it expires. I'm not sure if it's just a

--- a/server_test.go
+++ b/server_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -498,7 +499,7 @@ func makeTestCodeFlowLogin(location string) (*http.Response, error) {
 	// step: get the redirect
 	var resp *http.Response
 	for count := 0; count < 4; count++ {
-		req, err := http.NewRequest(http.MethodGet, location, nil)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, location, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* perf(tls): configured TLS session cache for proxy
* feat(tracing): enabled datadog-specific extensions in logger for APM log correlation
* chore(linting): updated linter config, addressed a few linting issues
* fix(cors): removed upstream cors headers from response, when cors enabled by the proxy

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>