### PR TITLE
feat: added required scopes option

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -58,6 +58,8 @@ type Config struct {
 	OAuthURI string `json:"oauth-uri" yaml:"oauth-uri" usage:"the uri for proxy oauth endpoints" env:"OAUTH_URI"`
 	// Scopes is a list of scope we should request
 	Scopes []string `json:"scopes" yaml:"scopes" usage:"list of scopes requested when authenticating the user"`
+	// RequiredScopes is a list of scope we require for a token to be valid
+	RequiredScopes []string `json:"required-scopes" yaml:"required-scopes" usage:"list of scopes required when authenticating the user"`
 	// Upstream is the upstream endpoint i.e whom were proxying to
 	Upstream string `json:"upstream-url" yaml:"upstream-url" usage:"url for the upstream endpoint you wish to proxy" env:"UPSTREAM_URL"`
 	// UpstreamCA is the path to a CA certificate in PEM format to validate the upstream certificate

--- a/errors.go
+++ b/errors.go
@@ -94,14 +94,18 @@ func (r *oauthProxy) accessForbidden(w http.ResponseWriter, req *http.Request, m
 	} else {
 		var msg string
 		if len(msgs) > 0 {
-			msg = msgs[0]
-			if len(msgs) > 1 {
-				// extraMsg goes to log but not to be returned as end user error
-				extraMsg := strings.Join(msgs[1:], " ")
-				r.log.Warn(extraMsg)
+			r.log.Warn("user forbidden access", zap.Strings("extra_messages", msgs))
+
+			switch len(msgs) {
+			case 1:
+				msg = msgs[0]
+			default: // > 1
+				msg = strings.Join(msgs[:2], " ")
 			}
 		}
+		// extraMsg goes to log but only the 2 first ones are to be returned as end user error
 		r.errorResponse(w, req, msg, http.StatusForbidden, nil)
 	}
+
 	return r.revokeProxy(w, req)
 }

--- a/middleware.go
+++ b/middleware.go
@@ -149,7 +149,7 @@ func (r *oauthProxy) authenticationMiddleware() func(http.Handler) http.Handler 
 				return
 			}
 
-			if err := verifyToken(r.client, user.token); err != nil {
+			if err := r.verifyToken(r.client, user.token); err != nil {
 				// step: if the error post verification is anything other than a token
 				// expired error we immediately throw an access forbidden - as there is
 				// something messed up in the token

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -322,7 +322,7 @@ func TestTokenExpired(t *testing.T) {
 			t.Errorf("case %d unable to sign the token, error: %s", i, err)
 			continue
 		}
-		err = verifyToken(px.client, *signed)
+		err = px.verifyToken(px.client, *signed)
 		if x.OK && err != nil {
 			t.Errorf("case %d, expected: %t got error: %s", i, x.OK, err)
 		}


### PR DESCRIPTION
The gatekeeper may now check for some scopes to be in the access token.

Our use case is to be able to specialize gateways and allow only some
users to connect via a gateway.

Adding this new check on the token raised an issue: whenever a user is
rejected by the reverse proxy gateway, but yet has a valid OIDC session
(e.g. valid but missing some scopes), the redirection workflow has to
revoke the session so the end user does not remain locked on this error
page and can restart a full workflow with a new identity.

Changes:
* added RequiredScopes option
* token validation (verifyToken): added required scopes validation
* error handling: allowing more details to go down to the end user about
the cause of the error
* logout handler: factored out the common logout/session revocation
logic so it is called either from the logout endpoint (with success) or
from the OAuth callback handler whenever it fails on the token
validation (with 403 error)
* logout: added some debug messages to that part, which exhibits many
variants
* logger: added the capability to decorate the internal logger with
fields (while still maintaining the logs to trace span feature)
Signed-off-by: Frederic BIDON <frederic@oneconcern.com>