### PR TITLE
Revert to set request_uri for redirect

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/base64"
 	"net/http"
 	"strconv"
 	"strings"
@@ -172,6 +173,8 @@ func (r *oauthProxy) dropRefreshTokenCookie(req *http.Request, w http.ResponseWr
 // writeStateParameterCookie sets a state parameter cookie into the response
 func (r *oauthProxy) writeStateParameterCookie(req *http.Request, w http.ResponseWriter) string {
 	uuid := uuid.NewString()
+	requestURI := base64.StdEncoding.EncodeToString([]byte(req.URL.RequestURI()))
+	r.dropCookie(w, req.Host, requestURICookie, requestURI, 0)
 	r.dropCookie(w, req.Host, requestStateCookie, uuid, 0)
 
 	return uuid


### PR DESCRIPTION
After browser authentication,  it is not redirected to the original request URI.
Revert to set request_uri in the cookie.