### PR TITLE
Fix X-Forwarded-Host behind reverse proxy

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"regexp"
 	"time"
 
 	"github.com/coreos/go-oidc/jose"
@@ -59,7 +60,7 @@ func (r *oauthProxy) getRedirectionURL(w http.ResponseWriter, req *http.Request)
 		// @QUESTION: should I use the X-Forwarded-<header>?? ..
 		redirect = fmt.Sprintf("%s://%s",
 			defaultTo(req.Header.Get("X-Forwarded-Proto"), scheme),
-			defaultTo(req.Header.Get("X-Forwarded-Host"), req.Host))
+			defaultTo(regexp.MustCompile(",\\s?").Split(req.Header.Get("X-Forwarded-Host"), 2)[0], req.Host))
 	default:
 		redirect = r.config.RedirectionURL
 	}

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -288,7 +288,11 @@ func (r *oauthProxy) proxyMiddleware(resource *Resource) func(http.Handler) http
 
 			// @step: add the proxy forwarding headers
 			req.Header.Add("X-Forwarded-For", realIP(req)) // TODO(fredbi): check if still necessary with net/http/httputil reverse proxy
-			req.Header.Set("X-Forwarded-Host", req.Host)
+			if fh := req.Header.Get("X-Forwarded-Host"); fh != "" {
+				req.Header.Set("X-Forwarded-Host", fh)
+			} else {
+				req.Header.Set("X-Forwarded-Host", req.Host)
+			}
 			if fp := req.Header.Get("X-Forwarded-Proto"); fp != "" {
 				req.Header.Set("X-Forwarded-Proto", fp)
 			} else {


### PR DESCRIPTION
If keycloak gatekeeper is behind reverse proxy, it doesn't work properly.
X-Forwarded-Host has multiple hosts.
X-Forwarded-Host should be kept.